### PR TITLE
Allow custom placeholder image and use transparent_image for default

### DIFF
--- a/flutter_map/lib/src/layer/tile_layer.dart
+++ b/flutter_map/lib/src/layer/tile_layer.dart
@@ -3,6 +3,7 @@ import 'dart:typed_data';
 import 'package:flutter/material.dart';
 import 'package:flutter/widgets.dart';
 import 'package:latlong/latlong.dart';
+import 'package:transparent_image/transparent_image.dart';
 import 'package:flutter_map/src/core/bounds.dart';
 import 'package:flutter_map/src/core/point.dart';
 import 'package:flutter_map/src/map/map.dart';
@@ -19,6 +20,7 @@ class TileLayerOptions extends LayerOptions {
   final double zoomOffset;
   final List<String> subdomains;
   final Color backgroundColor;
+  ImageProvider placeholderImage;
   Map<String, String> additionalOptions;
 
   TileLayerOptions({
@@ -30,6 +32,7 @@ class TileLayerOptions extends LayerOptions {
     this.additionalOptions = const <String, String>{},
     this.subdomains = const <String>[],
     this.backgroundColor = Colors.grey[300],
+    this.placeholderImage,
   });
 }
 
@@ -324,7 +327,6 @@ class _TileLayerState extends State<TileLayer> {
     var pos = (tilePos).multiplyBy(level.scale) + level.translatePoint;
     var width = tileSize.x * level.scale;
     var height = tileSize.y * level.scale;
-    var blankImageBytes = new Uint8List(0);
 
     return new Positioned(
       left: pos.x.toDouble(),
@@ -335,8 +337,9 @@ class _TileLayerState extends State<TileLayer> {
         child: new FadeInImage(
           fadeInDuration: const Duration(milliseconds: 100),
           key: new Key(_tileCoordsToKey(coords)),
-          // here `bytes` is a Uint8List containing the bytes for the in-memory image
-          placeholder: new MemoryImage(blankImageBytes),
+          placeholder: options.placeholderImage != null
+              ? options.placeholderImage
+              : new MemoryImage(kTransparentImage),
           image: new NetworkImage(getTileUrl(coords)),
           fit: BoxFit.fill,
         ),

--- a/flutter_map/pubspec.yaml
+++ b/flutter_map/pubspec.yaml
@@ -14,3 +14,4 @@ dependencies:
   latlong: ^0.4.0
   tuple: ^1.0.0
   quiver: ^0.28.0
+  transparent_image: ^0.1.0


### PR DESCRIPTION
This fixes continuous exceptions caused by the previous default MemoryImage being initialized with `new Uint8List(0)`

```
I/flutter (10904): Another exception was thrown: Exception: operation failed
E/flutter (10904): [ERROR:flutter/lib/ui/painting/codec.cc(83)] InitCodec failed - buffer was empty
I/chatty  (10904): uid=10093(net.nbspou.infapp) 1.io identical 17 lines
E/flutter (10904): [ERROR:flutter/lib/ui/painting/codec.cc(83)] InitCodec failed - buffer was empty
I/flutter (10904): Another exception was thrown: Exception: operation failed
```