### PR TITLE
Applied constraints to zoom on gesture update if min or max options set

### DIFF
--- a/flutter_map/lib/src/gestures/gestures.dart
+++ b/flutter_map/lib/src/gestures/gestures.dart
@@ -70,7 +70,13 @@ abstract class MapGestureMixin extends State<FlutterMap>
       var offsetPt = newCenter - map.project(_mapCenterStart);
       _animationOffset = _pointToOffset(offsetPt);
 
+      //Abide to min/max zoom
       var newZoom = _mapZoomStart * dScale;
+      if (options.maxZoom != null)
+        newZoom = (newZoom > options.maxZoom) ? options.maxZoom : newZoom;
+      if (options.minZoom != null)
+        newZoom = (newZoom < options.minZoom) ? options.minZoom : newZoom;
+
       map.move(map.unproject(newCenter), newZoom);
     });
   }


### PR DESCRIPTION
As per [Issue #42](https://github.com/apptreesoftware/flutter_map/issues/42), I have applied a min max constraint check on zoom within handleScaleUpdate in gestures.dart.