### PR TITLE
Pan Boundary with 2 new MapOptions variables: swPanBoundary and nePanBoundary.

### DIFF
--- a/flutter_map/lib/flutter_map.dart
+++ b/flutter_map/lib/flutter_map.dart
@@ -79,6 +79,8 @@ class MapOptions {
   final PositionCallback onPositionChanged;
   final List<MapPlugin> plugins;
   LatLng center;
+  LatLng swPanBoundary;
+  LatLng nePanBoundary;
 
   MapOptions({
     this.crs: const Epsg3857(),
@@ -92,8 +94,25 @@ class MapOptions {
     this.onTap,
     this.onPositionChanged,
     this.plugins = const [],
+    this.swPanBoundary,
+    this.nePanBoundary,
   }) {
     if (center == null) center = new LatLng(50.5, 30.51);
+    assert(!isOutOfBounds(center)); //You cannot start outside pan boundary
+  }
+
+  //if there is a pan boundary, do not cross
+  bool isOutOfBounds(LatLng center) {
+    if (this.swPanBoundary != null && this.nePanBoundary != null) {
+      if (center.latitude < this.swPanBoundary.latitude ||
+          center.latitude > this.nePanBoundary.latitude) {
+        return true;
+      } else if (center.longitude < this.swPanBoundary.longitude ||
+          center.longitude > this.nePanBoundary.longitude) {
+        return true;
+      }
+    }
+    return false;
   }
 }
 

--- a/flutter_map/lib/src/map/map.dart
+++ b/flutter_map/lib/src/map/map.dart
@@ -76,6 +76,10 @@ class MapState {
   }
 
   void move(LatLng center, double zoom) {
+    if (options.isOutOfBounds(center)) {
+      return;
+    }
+
     if (zoom == null) {
       zoom = _zoom;
     }
@@ -187,7 +191,8 @@ class MapState {
     var viewHalf = this.size / 2.0;
     return (this.project(center, zoom) - viewHalf).round();
   }
-Bounds getPixelBounds(double zoom) {
+
+  Bounds getPixelBounds(double zoom) {
     var mapZoom = zoom;
     var scale = getZoomScale(mapZoom, zoom);
     var pixelCenter = project(center, zoom).floor();


### PR DESCRIPTION
MapOptions now has 2 new variables, swPanBoundary and nwPanBoundary. Immediate assert fail if center variable is outside pan boundary. map.dart's move() function returns out if *new center is out of pan bounds.