### PR TITLE
OfflineMode bool variable added to TileLayerOptions for AssetImage Widget use

### DIFF
--- a/flutter_map/lib/src/layer/tile_layer.dart
+++ b/flutter_map/lib/src/layer/tile_layer.dart
@@ -20,6 +20,7 @@ class TileLayerOptions extends LayerOptions {
   final double zoomOffset;
   final List<String> subdomains;
   final Color backgroundColor;
+  final bool offlineMode;
 
   /// When panning the map, keep this many rows and columns of tiles before
   /// unloading them.
@@ -38,6 +39,7 @@ class TileLayerOptions extends LayerOptions {
     this.keepBuffer = 2,
     this.backgroundColor = const Color(0xFFE0E0E0), // grey[300]
     this.placeholderImage,
+    this.offlineMode = false,
   });
 }
 
@@ -374,7 +376,9 @@ class _TileLayerState extends State<TileLayer> {
           placeholder: options.placeholderImage != null
               ? options.placeholderImage
               : new MemoryImage(kTransparentImage),
-          image: new NetworkImage(getTileUrl(coords)),
+          image: options.offlineMode == true
+              ? new AssetImage(getTileUrl(coords))
+              : new NetworkImage(getTileUrl(coords)),
           fit: BoxFit.fill,
         ),
       ),


### PR DESCRIPTION
Resolves [issue 3](https://github.com/apptreesoftware/flutter_map/issues/3).
Added OfflineMode bool variable to TileLayerOptions, if true, image uses AssetImage(), if false (default) image uses NetworkImage(). 

Note: Only the newest (7th jun 2018) master build of flutter enables pubspec to look in asset directories, else pubspec will require direct paths to all map asset images. 

To get offline maps tiles, see here: [mbtilesToPngs](https://github.com/alfanhui/mbtilesToPngs)