### PR TITLE
Add double-tap to zoom

### DIFF
--- a/flutter_map/lib/src/map/flutter_map_state.dart
+++ b/flutter_map/lib/src/map/flutter_map_state.dart
@@ -30,6 +30,7 @@ class FlutterMapState extends MapGestureMixin {
         onScaleUpdate: handleScaleUpdate,
         onScaleEnd: handleScaleEnd,
         onTapUp: handleTapUp,
+        onDoubleTap: handleDoubleTap,
         child: new Container(
           child: new Stack(
             children: layerWidgets,


### PR DESCRIPTION
Added the necessary code to support double-tap to zoom. Also added a dispose function. Note that it zooms in the center, not where the user tapped. See https://github.com/flutter/flutter/issues/10048.

Closes https://github.com/apptreesoftware/flutter_map/issues/73