### PR TITLE
Upgrade latlong version from 0.4.0 to 0.5.3

### DIFF
--- a/flutter_map/pubspec.yaml
+++ b/flutter_map/pubspec.yaml
@@ -11,6 +11,6 @@ environment:
 dependencies:
   flutter:
     sdk: flutter
-  latlong: ^0.4.0
+  latlong: ^0.5.3
   tuple: ^1.0.0
   transparent_image: ^0.1.0


### PR DESCRIPTION
After upgrading to flutter 0.5.8-pre.155 I'm getting an error on missing math.PI (which was obsolete)

flutter version:
```bash
Flutter 0.5.8-pre.155 • channel master • https://github.com/flutter/flutter.git
Framework • revision 78a00cb13a (6 days ago) • 2018-08-01 22:56:49 -0700
Engine • revision a61fae0824
Tools • Dart 2.0.0-dev.69.3.flutter-937ee2e8ca
```

And the error:
```bash
compiler message: file:///Users/aroba/flutter/.pub-cache/hosted/pub.dartlang.org/latlong-0.4.5/lib/latlong.dart:74:53: Error: Getter not found: 'PI'.
compiler message: double degToRadian(final double deg) => deg * (math.PI / 180.0);
compiler message:                                                     ^^
compiler message: file:///Users/aroba/flutter/.pub-cache/hosted/pub.dartlang.org/latlong-0.4.5/lib/latlong.dart:77:61: Error: Getter not found: 'PI'.
compiler message: double radianToDeg(final double rad) => rad * (180.0 / math.PI);
compiler message:                                                             ^^
compiler message: file:///Users/aroba/flutter/.pub-cache/hosted/pub.dartlang.org/latlong-0.4.5/lib/latlong/calculator/Vincenty.dart:120:34: Error: Getter not found: 'PI'.
compiler message:         double sigmaP = 2 * math.PI;
compiler message:                                  ^^
compiler message: file:///Users/aroba/flutter/.pub-cache/hosted/pub.dartlang.org/latlong-0.4.5/lib/latlong/calculator/Vincenty.dart:158:25: Error: Getter not found: 'PI'.
compiler message:         if (lon2 > math.PI) {
compiler message:                         ^^
compiler message: file:///Users/aroba/flutter/.pub-cache/hosted/pub.dartlang.org/latlong-0.4.5/lib/latlong/calculator/Vincenty.dart:159:36: Error: Getter not found: 'PI'.
compiler message:             lon2 = lon2 - 2 * math.PI;
compiler message:                                    ^^
compiler message: file:///Users/aroba/flutter/.pub-cache/hosted/pub.dartlang.org/latlong-0.4.5/lib/latlong/calculator/Vincenty.dart:161:30: Error: Getter not found: 'PI'.
compiler message:         if (lon2 < -1 * math.PI) {
compiler message:                              ^^
compiler message: file:///Users/aroba/flutter/.pub-cache/hosted/pub.dartlang.org/latlong-0.4.5/lib/latlong/calculator/Vincenty.dart:162:36: Error: Getter not found: 'PI'.
compiler message:             lon2 = lon2 + 2 * math.PI;
compiler message:
```