### PR TITLE
Fix imports within library

### DIFF
--- a/flutter_map/lib/flutter_map.dart
+++ b/flutter_map/lib/flutter_map.dart
@@ -4,14 +4,14 @@ import 'dart:async';
 
 import 'package:flutter/widgets.dart';
 import 'package:flutter/material.dart';
-import 'package:flutter_map/flutter_map.dart';
-import 'package:flutter_map/src/core/point.dart';
-import 'package:flutter_map/src/geo/crs/crs.dart';
-import 'package:flutter_map/src/map/flutter_map_state.dart';
-import 'package:flutter_map/src/map/map.dart';
-import 'package:flutter_map/src/plugins/plugin.dart';
 import 'package:latlong/latlong.dart';
 
+import 'flutter_map.dart';
+import 'src/core/point.dart';
+import 'src/geo/crs/crs.dart';
+import 'src/map/flutter_map_state.dart';
+import 'src/map/map.dart';
+import 'src/plugins/plugin.dart';
 export 'src/plugins/plugin.dart';
 export 'src/layer/layer.dart';
 export 'src/layer/tile_layer.dart';
@@ -19,7 +19,7 @@ export 'src/layer/marker_layer.dart';
 export 'src/layer/polyline_layer.dart';
 export 'src/geo/crs/crs.dart';
 export 'src/geo/latlng_bounds.dart';
-export 'package:flutter_map/src/core/point.dart';
+export 'src/core/point.dart';
 
 class FlutterMap extends StatefulWidget {
   /// A set of layers' options to used to create the layers on the map

--- a/flutter_map/lib/src/geo/crs/crs.dart
+++ b/flutter_map/lib/src/geo/crs/crs.dart
@@ -2,9 +2,9 @@ import 'dart:math' as math;
 
 import 'package:tuple/tuple.dart';
 import 'package:latlong/latlong.dart';
-import 'package:flutter_map/src/core/bounds.dart';
 
-import 'package:flutter_map/src/core/point.dart';
+import '../../core/bounds.dart';
+import '../../core/point.dart';
 
 abstract class Crs {
   String get code;

--- a/flutter_map/lib/src/gestures/gestures.dart
+++ b/flutter_map/lib/src/gestures/gestures.dart
@@ -2,10 +2,11 @@ import 'dart:math' as math;
 
 import 'package:flutter/material.dart';
 import 'package:flutter/widgets.dart';
-import 'package:flutter_map/src/core/point.dart';
-import 'package:flutter_map/src/map/map.dart';
 import 'package:latlong/latlong.dart';
-import 'package:flutter_map/flutter_map.dart';
+
+import '../core/point.dart';
+import '../map/map.dart';
+import '../../flutter_map.dart';
 
 abstract class MapGestureMixin extends State<FlutterMap>
     with TickerProviderStateMixin {

--- a/flutter_map/lib/src/layer/marker_layer.dart
+++ b/flutter_map/lib/src/layer/marker_layer.dart
@@ -1,7 +1,7 @@
 import 'package:flutter/widgets.dart';
-import 'package:flutter_map/src/map/map.dart';
+import '../map/map.dart';
 import 'package:latlong/latlong.dart';
-import 'package:flutter_map/flutter_map.dart';
+import '../../flutter_map.dart';
 
 class MarkerLayerOptions extends LayerOptions {
   final List<Marker> markers;

--- a/flutter_map/lib/src/layer/polyline_layer.dart
+++ b/flutter_map/lib/src/layer/polyline_layer.dart
@@ -1,9 +1,10 @@
 import 'dart:ui';
 
 import 'package:flutter/widgets.dart';
-import 'package:flutter_map/flutter_map.dart';
-import 'package:flutter_map/src/map/map.dart';
 import 'package:latlong/latlong.dart';
+
+import '../../flutter_map.dart';
+import '../map/map.dart';
 
 class PolylineLayerOptions extends LayerOptions {
   final List<Polyline> polylines;

--- a/flutter_map/lib/src/layer/tile_layer.dart
+++ b/flutter_map/lib/src/layer/tile_layer.dart
@@ -4,12 +4,13 @@ import 'package:flutter/material.dart';
 import 'package:flutter/widgets.dart';
 import 'package:latlong/latlong.dart';
 import 'package:transparent_image/transparent_image.dart';
-import 'package:flutter_map/src/core/bounds.dart';
-import 'package:flutter_map/src/core/point.dart';
-import 'package:flutter_map/src/map/map.dart';
-import 'package:flutter_map/src/core/util.dart' as util;
 import 'package:tuple/tuple.dart';
 import 'layer.dart';
+
+import '../core/bounds.dart';
+import '../core/point.dart';
+import '../map/map.dart';
+import '../core/util.dart' as util;
 
 class TileLayerOptions extends LayerOptions {
   final String urlTemplate;

--- a/flutter_map/lib/src/map/flutter_map_state.dart
+++ b/flutter_map/lib/src/map/flutter_map_state.dart
@@ -1,8 +1,9 @@
 import 'package:flutter/widgets.dart';
-import 'package:flutter_map/flutter_map.dart';
-import 'package:flutter_map/src/core/point.dart';
-import 'package:flutter_map/src/gestures/gestures.dart';
-import 'package:flutter_map/src/map/map.dart';
+
+import '../../flutter_map.dart';
+import '../core/point.dart';
+import '../gestures/gestures.dart';
+import '../map/map.dart';
 
 class FlutterMapState extends MapGestureMixin {
   final MapControllerImpl mapController;

--- a/flutter_map/lib/src/map/map.dart
+++ b/flutter_map/lib/src/map/map.dart
@@ -1,11 +1,12 @@
 import 'dart:async';
 import 'dart:math' as math;
 
-import 'package:flutter_map/src/core/center_zoom.dart';
 import 'package:latlong/latlong.dart';
-import 'package:flutter_map/flutter_map.dart';
-import 'package:flutter_map/src/core/bounds.dart';
-import 'package:flutter_map/src/core/point.dart';
+
+import '../core/center_zoom.dart';
+import '../../flutter_map.dart';
+import '../core/bounds.dart';
+import '../core/point.dart';
 
 class MapControllerImpl implements MapController {
   Completer<Null> _readyCompleter = new Completer<Null>();

--- a/flutter_map/lib/src/plugins/plugin.dart
+++ b/flutter_map/lib/src/plugins/plugin.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/widgets.dart';
-import 'package:flutter_map/src/layer/layer.dart';
-import 'package:flutter_map/src/map/map.dart';
+
+import '../layer/layer.dart';
+import '../map/map.dart';
 
 abstract class MapPlugin {
   bool supportsLayer(LayerOptions options);


### PR DESCRIPTION
Consistently import library files using relative path.
Don't use `package:` imports for files within the library as it seems to cause the types to be duplicated in another namespace causing mysterious type mismatch issues (The hashCode of a type from the library itself imported through relative path vs imported using package ends up being different).