### PR TITLE
Expose map bounds

### DIFF
--- a/example/lib/pages/map_controller.dart
+++ b/example/lib/pages/map_controller.dart
@@ -13,6 +13,7 @@ class MapControllerPage extends StatefulWidget {
 }
 
 class MapControllerPageState extends State<MapControllerPage> {
+  final GlobalKey<ScaffoldState> _scaffoldKey = new GlobalKey<ScaffoldState>();
   static LatLng london = new LatLng(51.5, -0.09);
   static LatLng paris = new LatLng(48.8566, 2.3522);
   static LatLng dublin = new LatLng(53.3498, -6.2603);
@@ -31,7 +32,7 @@ class MapControllerPageState extends State<MapControllerPage> {
         height: 80.0,
         point: london,
         builder: (ctx) => new Container(
-          key: new Key("blue"),
+              key: new Key("blue"),
               child: new FlutterLogo(),
             ),
       ),
@@ -51,13 +52,14 @@ class MapControllerPageState extends State<MapControllerPage> {
         height: 80.0,
         point: paris,
         builder: (ctx) => new Container(
-          key: new Key("purple"),
+              key: new Key("purple"),
               child: new FlutterLogo(colors: Colors.purple),
             ),
       ),
     ];
 
     return new Scaffold(
+      key: _scaffoldKey,
       appBar: new AppBar(title: new Text("MapController")),
       drawer: buildDrawer(context, MapControllerPage.route),
       body: new Padding(
@@ -108,6 +110,22 @@ class MapControllerPageState extends State<MapControllerPage> {
                       );
                     },
                   ),
+                  new MaterialButton(
+                    child: new Text("Get Bounds"),
+                    onPressed: () {
+                      final bounds = mapController.bounds;
+
+                      _scaffoldKey.currentState.showSnackBar(new SnackBar(
+                        content: new Text(
+                          'Map bounds: \n'
+                              'E: ${bounds.east} \n'
+                              'N: ${bounds.north} \n'
+                              'W: ${bounds.west} \n'
+                              'S: ${bounds.south}',
+                        ),
+                      ));
+                    },
+                  ),
                 ],
               ),
             ),
@@ -118,7 +136,7 @@ class MapControllerPageState extends State<MapControllerPage> {
                   center: new LatLng(51.5, -0.09),
                   zoom: 5.0,
                   maxZoom: 5.0,
-                  minZoom: 3.0
+                  minZoom: 3.0,
                 ),
                 layers: [
                   new TileLayerOptions(

--- a/lib/flutter_map.dart
+++ b/lib/flutter_map.dart
@@ -130,6 +130,7 @@ class FitBoundsOptions {
 
 class MapPosition {
   final LatLng center;
+  final LatLngBounds bounds;
   final double zoom;
-  MapPosition({this.center, this.zoom});
+  MapPosition({this.center, this.bounds, this.zoom});
 }

--- a/lib/flutter_map.dart
+++ b/lib/flutter_map.dart
@@ -59,6 +59,7 @@ abstract class MapController {
   bool get ready;
   Future<Null> get onReady;
   LatLng get center;
+  LatLngBounds get bounds;
   double get zoom;
 
   factory MapController() => new MapControllerImpl();

--- a/lib/src/layer/marker_layer.dart
+++ b/lib/src/layer/marker_layer.dart
@@ -85,9 +85,6 @@ class MarkerLayer extends StatelessWidget {
         var markers = <Widget>[];
         for (var markerOpt in this.markerOpts.markers) {
           var pos = map.project(markerOpt.point);
-          var bounds = map.getPixelBounds(map.zoom);
-          var latlngBounds = new LatLngBounds(
-              map.unproject(bounds.bottomLeft), map.unproject(bounds.topRight));
           pos = pos.multiplyBy(map.getZoomScale(map.zoom, map.zoom)) -
               map.getPixelOrigin();
 
@@ -96,7 +93,7 @@ class MarkerLayer extends StatelessWidget {
           var pixelPosY =
               (pos.y - (markerOpt.height - markerOpt._anchor.top)).toDouble();
 
-          if (!latlngBounds.contains(markerOpt.point)) {
+          if (!map.bounds.contains(markerOpt.point)) {
             continue;
           }
 

--- a/lib/src/map/map.dart
+++ b/lib/src/map/map.dart
@@ -36,6 +36,8 @@ class MapControllerImpl implements MapController {
 
   LatLng get center => _state.center;
 
+  LatLngBounds get bounds => _state.bounds;
+
   double get zoom => _state.zoom;
 }
 

--- a/lib/src/map/map.dart
+++ b/lib/src/map/map.dart
@@ -48,6 +48,7 @@ class MapState {
   double get zoom => _zoom;
 
   LatLng _lastCenter;
+  LatLngBounds _lastBounds;
   Point _pixelOrigin;
   bool _initialized = false;
 
@@ -69,6 +70,8 @@ class MapState {
   }
 
   LatLng get center => getCenter() ?? options.center;
+
+  LatLngBounds get bounds => getBounds();
 
   void _init() {
     _zoom = options.zoom;
@@ -98,6 +101,7 @@ class MapState {
 
     _zoom = zoom;
     _lastCenter = center;
+    _lastBounds = _calculateBounds();
     _pixelOrigin = getNewPixelOrigin(center);
     _onMoveSink.add(null);
 
@@ -119,6 +123,22 @@ class MapState {
       return _lastCenter;
     }
     return layerPointToLatLng(_centerLayerPoint);
+  }
+
+  LatLngBounds getBounds() {
+    if (_lastBounds != null) {
+      return _lastBounds;
+    }
+
+    return _calculateBounds();
+  }
+
+  LatLngBounds _calculateBounds() {
+    var bounds = getPixelBounds(zoom);
+    return new LatLngBounds(
+      unproject(bounds.bottomLeft),
+      unproject(bounds.topRight),
+    );
   }
 
   CenterZoom _getBoundsCenterZoom(

--- a/lib/src/map/map.dart
+++ b/lib/src/map/map.dart
@@ -106,7 +106,11 @@ class MapState {
     _onMoveSink.add(null);
 
     if (options.onPositionChanged != null) {
-      options.onPositionChanged(new MapPosition(center: center, zoom: zoom));
+      options.onPositionChanged(new MapPosition(
+        center: center,
+        bounds: bounds,
+        zoom: zoom,
+      ));
     }
   }
 


### PR DESCRIPTION
Provides a way for clients to get the current map bounds.

Fixes #87 

- Calculates the map bounds on `move`.
- Caches the value in `MapState` and exposes a `bounds` getter.
- Adds `bounds` property to `MapPosition`, and provides it upon triggering the `onPositionChanged` callback.
- Adds `bounds` getter to `MapController`/`MapControllerImpl`.
- Updates the MapController example with a button that shows the current bounds in a `SnackBar`.
