### PR TITLE
Filter map position changes with distinct and debounce operators

### DIFF
--- a/lib/flutter_map.dart
+++ b/lib/flutter_map.dart
@@ -79,7 +79,7 @@ class MapOptions {
   final bool debug;
   final bool interactive;
   final TapCallback onTap;
-  final PositionCallback onPositionChanged;
+  final PositionListener positionListener;
   final List<MapPlugin> plugins;
   LatLng center;
   LatLng swPanBoundary;
@@ -95,7 +95,7 @@ class MapOptions {
     this.debug = false,
     this.interactive = true,
     this.onTap,
-    this.onPositionChanged,
+    this.positionListener,
     this.plugins = const [],
     this.swPanBoundary,
     this.nePanBoundary,
@@ -136,4 +136,13 @@ class MapPosition {
   final LatLngBounds bounds;
   final double zoom;
   MapPosition({this.center, this.bounds, this.zoom});
+}
+
+class PositionListener {
+  PositionCallback onChanged;
+  Duration debounce;
+  PositionListener({
+    @required this.onChanged,
+    this.debounce = Duration.zero,
+  });
 }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -14,3 +14,4 @@ dependencies:
   tuple: ^1.0.1
   latlong: ^0.6.1
   transparent_image: ^0.1.0
+  rxdart: 0.18.1


### PR DESCRIPTION
Map position changes are emitted via stream and transformed with `distinct` and `debounce`. It will prevent two or more identical consecutive positions to invoke callback multiple times and will allow to receive callback once the movement is finished (and ignore all preceding position changes), e.g.:
```
FlutterMap(
  options: MapOptions(
    // ...
    positionListener: PositionListener(
      debounce: Duration(milliseconds: 100),
      onChanged: (position) => print("Position changed: ${position.center}"),
    ),
  ),
)
```