### PR TITLE
Update the version number in the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Add flutter_map to your pubspec:
 
 ```yaml
 dependencies:
-  flutter_map: ^0.0.1
+  flutter_map: ^0.1.4
 ```
 
 Configure the map using `MapOptions` and layer options:


### PR DESCRIPTION
The pubspec example in the README is badly out of date in its version number, which isn't good as people will tend to copy and paste that line as-is into their pubspecs.