### PR TITLE
Prevent map layers excessive builds

### DIFF
--- a/lib/src/map/flutter_map_state.dart
+++ b/lib/src/map/flutter_map_state.dart
@@ -32,6 +32,8 @@ class FlutterMapState extends MapGestureMixin {
         onTapUp: handleTapUp,
         onDoubleTap: handleDoubleTap,
         child: new Container(
+          width: constraints.maxWidth,
+          height: constraints.maxHeight,
           child: new Stack(
             children: layerWidgets,
           ),


### PR DESCRIPTION
Fixes the issue where all layers get rebuilt, whenever only one of them change its bounds https://github.com/apptreesoftware/flutter_map/issues/130.