### PR TITLE
Added rebuild capabiltiy to LayerOptions

### DIFF
--- a/example/lib/pages/plugin_api.dart
+++ b/example/lib/pages/plugin_api.dart
@@ -46,7 +46,7 @@ class MyCustomPluginOptions extends LayerOptions {
 
 class MyCustomPlugin implements MapPlugin {
   @override
-  Widget createLayer(LayerOptions options, MapState mapState) {
+  Widget createLayer(LayerOptions options, MapState mapState, Stream<Null> stream) {
     if (options is MyCustomPluginOptions) {
       var style = new TextStyle(
         fontWeight: FontWeight.bold,

--- a/lib/src/layer/layer.dart
+++ b/lib/src/layer/layer.dart
@@ -1,4 +1,5 @@
 class LayerOptions {
-
+  Stream<Null> rebuild;
+  LayerOptions({this.rebuild});
 }
 

--- a/lib/src/layer/marker_layer.dart
+++ b/lib/src/layer/marker_layer.dart
@@ -5,7 +5,8 @@ import 'package:flutter_map/flutter_map.dart';
 
 class MarkerLayerOptions extends LayerOptions {
   final List<Marker> markers;
-  MarkerLayerOptions({this.markers = const []});
+  MarkerLayerOptions({this.markers = const [], rebuild})
+      : super(rebuild: rebuild);
 }
 
 class Anchor {
@@ -75,12 +76,13 @@ class Marker {
 class MarkerLayer extends StatelessWidget {
   final MarkerLayerOptions markerOpts;
   final MapState map;
+  final Stream<Null> stream;
 
-  MarkerLayer(this.markerOpts, this.map);
+  MarkerLayer(this.markerOpts, this.map, this.stream);
 
   Widget build(BuildContext context) {
     return new StreamBuilder<int>(
-      stream: map.onMoved, // a Stream<int> or null
+      stream: stream, // a Stream<int> or null
       builder: (BuildContext context, AsyncSnapshot<int> snapshot) {
         var markers = <Widget>[];
         for (var markerOpt in this.markerOpts.markers) {

--- a/lib/src/layer/polygon_layer.dart
+++ b/lib/src/layer/polygon_layer.dart
@@ -8,7 +8,8 @@ import 'package:latlong/latlong.dart' hide Path;  // conflict with Path from UI
 
 class PolygonLayerOptions extends LayerOptions {
   final List<Polygon> polygons;
-  PolygonLayerOptions({this.polygons = const []});
+  PolygonLayerOptions({this.polygons = const [], rebuild})
+      : super(rebuild: rebuild);
 }
 
 class Polygon {
@@ -28,7 +29,9 @@ class Polygon {
 class PolygonLayer extends StatelessWidget {
   final PolygonLayerOptions polygonOpts;
   final MapState map;
-  PolygonLayer(this.polygonOpts, this.map);
+  final Stream<Null> stream;
+
+  PolygonLayer(this.polygonOpts, this.map, this.stream);
 
   Widget build(BuildContext context) {
     return new LayoutBuilder(
@@ -41,7 +44,7 @@ class PolygonLayer extends StatelessWidget {
 
   Widget _build(BuildContext context, Size size) {
     return new StreamBuilder<int>(
-      stream: map.onMoved, // a Stream<int> or null
+      stream: stream, // a Stream<int> or null
       builder: (BuildContext context, _) {
         for (var polygonOpt in polygonOpts.polygons) {
           polygonOpt.offsets.clear();

--- a/lib/src/layer/polyline_layer.dart
+++ b/lib/src/layer/polyline_layer.dart
@@ -8,7 +8,8 @@ import 'package:latlong/latlong.dart';
 
 class PolylineLayerOptions extends LayerOptions {
   final List<Polyline> polylines;
-  PolylineLayerOptions({this.polylines = const []});
+  PolylineLayerOptions({this.polylines = const [], rebuild})
+      : super(rebuild: rebuild);
 }
 
 class Polyline {
@@ -32,7 +33,9 @@ class Polyline {
 class PolylineLayer extends StatelessWidget {
   final PolylineLayerOptions polylineOpts;
   final MapState map;
-  PolylineLayer(this.polylineOpts, this.map);
+  final Stream<Null> stream;
+
+  PolylineLayer(this.polylineOpts, this.map, this.stream);
 
   Widget build(BuildContext context) {
     return new LayoutBuilder(
@@ -45,7 +48,7 @@ class PolylineLayer extends StatelessWidget {
 
   Widget _build(BuildContext context, Size size) {
     return new StreamBuilder<int>(
-      stream: map.onMoved, // a Stream<int> or null
+      stream: stream, // a Stream<int> or null
       builder: (BuildContext context, _) {
         for (var polylineOpt in polylineOpts.polylines) {
           polylineOpt.offsets.clear();

--- a/lib/src/layer/tile_layer.dart
+++ b/lib/src/layer/tile_layer.dart
@@ -94,16 +94,18 @@ class TileLayerOptions extends LayerOptions {
     this.placeholderImage,
     this.offlineMode = false,
     this.fromAssets = true,
-  });
+    rebuild}) : super(rebuild: rebuild);
 }
 
 class TileLayer extends StatefulWidget {
   final TileLayerOptions options;
   final MapState mapState;
+  final Stream<Null> stream;
 
   TileLayer({
     this.options,
     this.mapState,
+    this.stream,
   });
 
   State<StatefulWidget> createState() {
@@ -128,7 +130,7 @@ class _TileLayerState extends State<TileLayer> {
   void initState() {
     super.initState();
     _resetView();
-    _moveSub = map.onMoved.listen((_) => _handleMove());
+    _moveSub = widget.stream.listen((_) => _handleMove());
   }
 
   void dispose() {

--- a/lib/src/map/flutter_map_state.dart
+++ b/lib/src/map/flutter_map_state.dart
@@ -3,9 +3,11 @@ import 'package:flutter_map/flutter_map.dart';
 import 'package:flutter_map/src/core/point.dart';
 import 'package:flutter_map/src/gestures/gestures.dart';
 import 'package:flutter_map/src/map/map.dart';
+import 'package:async/async.dart';
 
 class FlutterMapState extends MapGestureMixin {
   final MapControllerImpl mapController;
+  final List<StreamGroup<Null>> groups = <StreamGroup<Null>>[];
   MapOptions get options => widget.options ?? new MapOptions();
   MapState mapState;
 
@@ -17,7 +19,31 @@ class FlutterMapState extends MapGestureMixin {
     mapController.state = mapState;
   }
 
+  void _dispose() {
+    groups.forEach((group) => group.close());
+    groups.clear();
+  }
+
+
+  @override
+  void dispose() {
+    _dispose();
+    super.dispose();
+  }
+
+  Stream<Null> _merge(LayerOptions options) {
+    if(options?.rebuild == null)
+      return mapState.onMoved;
+
+    StreamGroup<Null> group = new StreamGroup<Null>();
+    group.add(mapState.onMoved);
+    group.add(options.rebuild);
+    groups.add(group);
+    return group.stream;
+  }
+
   Widget build(BuildContext context) {
+    _dispose();
     return new LayoutBuilder(
         builder: (BuildContext context, BoxConstraints constraints) {
       mapState.size =
@@ -42,20 +68,20 @@ class FlutterMapState extends MapGestureMixin {
 
   Widget _createLayer(LayerOptions options, List<MapPlugin> plugins) {
     if (options is TileLayerOptions) {
-      return new TileLayer(options: options, mapState: mapState);
+      return new TileLayer(options: options, mapState: mapState, stream: _merge(options));
     }
     if (options is MarkerLayerOptions) {
-      return new MarkerLayer(options, mapState);
+      return new MarkerLayer(options, mapState, _merge(options));
     }
     if (options is PolylineLayerOptions) {
-      return new PolylineLayer(options, mapState);
+      return new PolylineLayer(options, mapState, _merge(options));
     }
     if (options is PolygonLayerOptions) {
-      return new PolygonLayer(options, mapState);
+      return new PolygonLayer(options, mapState, _merge(options));
     }
     for (var plugin in plugins) {
       if (plugin.supportsLayer(options)) {
-        return plugin.createLayer(options, mapState);
+        return plugin.createLayer(options, mapState, _merge(options));
       }
     }
     return null;

--- a/lib/src/plugins/plugin.dart
+++ b/lib/src/plugins/plugin.dart
@@ -4,5 +4,5 @@ import 'package:flutter_map/src/map/map.dart';
 
 abstract class MapPlugin {
   bool supportsLayer(LayerOptions options);
-  Widget createLayer(LayerOptions options, MapState mapState);
+  Widget createLayer(LayerOptions options, MapState mapState, Stream<Null> stream);
 }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -14,3 +14,4 @@ dependencies:
   tuple: ^1.0.1
   latlong: ^0.6.1
   transparent_image: ^0.1.0
+  async: ^2.0.8


### PR DESCRIPTION
Added rebuild capability using official package `package:async/async.dart` and `StreamGroup` to merge user-specified rebuild stream in `LayerOptions` with `onMoved` stream in `MapState`. Each time a new item is added to either stream, the `StreamBuilder` in each layer widget rebuilds the layer. 

**Details**
A new `StreamGroup` is created for each new layer created in the build method of `FlutterMapState`. `StreamGroup` instances created during last build are discarded before new `StreamGroups` are created and when the `StatefulWidget` implementing each layer is disposed, ensuring proper release of stream resources. 

Close #142. 