### PR TITLE
callback support for polyline, polygon & circle layers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,7 @@
+# CHANGELOG
+
 ## [0.2.0] - 10/25/2018
+
 - Use NetworkImageWithRetry for tile layers (#145)
 - Add rebuild capability to LayerOptions (#144)
 - Added Circle layer (#137)
@@ -7,21 +10,24 @@
 Thanks to @kengu, @mortenboye, and @tomwyr for this release!
 
 ## [0.1.4] - 9/24/2018
+
 - Polygon Support (#118)
 
 Thanks to @JulianBerger for this release!
 
 ## [0.1.3] - 9/18/2018
+
 - fix identical map position callbacks (#111)
 - Prune tiles bug fix (#112)
 
 Thanks to @IhorKlimov and @tomwyr for this release!
 
 ## [0.1.2] - 8/21/2018
-- Added polyline customisation options (#94)
+
+- Added polyline customization options (#94)
 - Expose map bounds (#99)
 - Added onTap example (#103)
-- route bugfix (#104)
+- route bug fix (#104)
 - options is now required (#105)
 - Project refactor and changes to offline map #85
 
@@ -29,12 +35,15 @@ Thanks to @LJaraCastillo, @ubilabs, @xqwzts, @vinicentus, and @lsaudon for this
 release!
 
 ## [0.1.0] - 8/21/2018
+
 - Set Dart SDK to ">=2.0.0 <3.0.0"
 
 ## [0.0.11] - 8/2/2018
+
 - upgrade to latlong from 0.4.0 to 0.5.3
 
 ## [0.0.11] - 7/31/2018
+
 - fix LICENSE spelling error
 - double-tap to zoom (#62)
 - Fix polyline overlap issue (#67)
@@ -44,26 +53,30 @@ Thanks to contributors @alfanhui, @avioli, @solid-software, and @vinicentus for
 this release!
 
 ## [0.0.10] - 6/7/2018
+
 - update .gitignore (#40)
 - Applied constraints to zoom on gesture update if min or max options set (#46)
-- Pan Boundary with 2 new MapOptions variables: swPanBoundary and nePanBoundary
-(#47)
+- Pan Boundary with 2 new MapOptions variables: swPanBoundary and nePanBoundary (#47)
 - OfflineMode bool variable added to TileLayerOptions for AssetImage Widget use (#48)
 - remove quiver dep (#32)
 
 Thanks to contributors @avioli, @bcko, and @alfanhui for this release!
 
 ## [0.0.9] - 5/31/2018
+
 - add LatlngBounds.contains, avoid rendering out-of-view markers in MarkerLayer
 
 ## [0.0.8] - 5/31/2018
+
 - bug: rendering far-away tiles was causing a GPU crash on the simulator. add
   tile pruning to TileLayer
 
 ## [0.0.7] - 5/29/2018
+
 - bug: TileLayer not listening to onMoved events from MapController
 
 ## [0.0.6] - 5/11/2018
+
 - fitBounds, onPositionChanged (#39)
 
 ## [0.0.5] - 3/11/2018
@@ -82,7 +95,7 @@ Thanks to contributors @avioli, @bcko, and @alfanhui for this release!
 
 ## [0.0.2] - 2/21/2018
 
-- subdomain support
+- sub-domain support
 - move gesture detection into map widget
 - improved tile layer support
 - improved examples
@@ -91,5 +104,4 @@ Thanks to contributors @avioli, @bcko, and @alfanhui for this release!
 
 ## [0.0.1] - 2/5/2018
 
-- inital release
-
+- initial release

--- a/README.md
+++ b/README.md
@@ -76,18 +76,16 @@ new TileLayerOptions(
 ),
 ```
 
-
 To use, you'll need a mapbox key:
 
 1. Create a [Mapbox] account to get an api key
-2. open leaflet_flutter_example/lib/main.dart and paste the API key into the
-`additionalOptions` map.
-
+2. open leaflet_flutter_example/lib/main.dart and paste the API key into the`additionalOptions` map.
 
 ## Offline maps
-[Follow this guide to grab offline tiles](https://tilemill-project.github.io/tilemill/docs/guides/osm-bright-mac-quickstart/)<br>
-Once you have your map exported to `.mbtiles`, you can use [mbtilesToPng](https://github.com/alfanhui/mbtilesToPngs) to unpack into `/{z}/{x}/{y}.png`. Move this to Assets folder and add  Asset directories to `pubspec.yaml`. Minimum required fields for offline maps are:
-```
+
+[Follow this guide to grab offline tiles](https://tilemill-project.github.io/tilemill/docs/guides/osm-bright-mac-quickstart/) Once you have your map exported to `.mbtiles`, you can use [mbtilesToPng](https://github.com/alfanhui/mbtilesToPngs) to unpack into `/{z}/{x}/{y}.png`. Move this to Assets folder and add  Asset directories to `pubspec.yaml`. Minimum required fields for offline maps are:
+
+```dart
 new FlutterMap(
   options: new MapOptions(
     center: new LatLng(56.704173, 11.543808),
@@ -106,12 +104,14 @@ new FlutterMap(
   ],
 ),
 ```
-Make sure PanBoundaries are within offline map boundary to stop missing asset errors.<br>
-See the `flutter_map_example/` folder for a working example.<br>
+
+Make sure PanBoundaries are within offline map boundary to stop missing asset errors.
+
+See the `flutter_map_example/` folder for a working example.
 
 ## Roadmap
 
-For the latest roadmap, please see the [Issue Tracker] 
+For the latest roadmap, please see the [Issue Tracker]
 
 [Leaflet]: http://leafletjs.com/
 [Mapbox]: https://www.mapbox.com/

--- a/example/android/app/build.gradle
+++ b/example/android/app/build.gradle
@@ -15,8 +15,8 @@ apply plugin: 'com.android.application'
 apply from: "$flutterRoot/packages/flutter_tools/gradle/flutter.gradle"
 
 android {
-    compileSdkVersion 25
-    buildToolsVersion '25.0.3'
+    compileSdkVersion 28
+    buildToolsVersion '28.0.3'
 
     lintOptions {
         disable 'InvalidPackage'
@@ -26,7 +26,7 @@ android {
         // TODO: Specify your own unique Application ID (https://developer.android.com/studio/build/application-id.html).
         applicationId "com.johnpryan.leafletflutterexample"
         minSdkVersion 16
-        targetSdkVersion 25
+        targetSdkVersion 28
         versionCode 1
         versionName "1.0"
         testInstrumentationRunner "android.support.test.runner.AndroidJUnitRunner"
@@ -46,7 +46,7 @@ flutter {
 }
 
 dependencies {
-    androidTestCompile 'com.android.support:support-annotations:25.4.0'
-    androidTestCompile 'com.android.support.test:runner:0.5'
-    androidTestCompile 'com.android.support.test:rules:0.5'
+    androidTestImplementation 'com.android.support:support-annotations:25.4.0'
+    androidTestImplementation 'com.android.support.test:runner:0.5'
+    androidTestImplementation 'com.android.support.test:rules:0.5'
 }

--- a/example/android/build.gradle
+++ b/example/android/build.gradle
@@ -1,22 +1,17 @@
 buildscript {
     repositories {
+        google()
         jcenter()
-        maven {
-            url "https://maven.google.com"
-        }
     }
-
     dependencies {
-        classpath 'com.android.tools.build:gradle:2.3.3'
+        classpath 'com.android.tools.build:gradle:3.2.1'
     }
 }
 
 allprojects {
     repositories {
+        google()
         jcenter()
-        maven {
-            url "https://maven.google.com"
-        }
     }
 }
 

--- a/example/android/gradle/wrapper/gradle-wrapper.properties
+++ b/example/android/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Fri Jun 23 08:50:38 CEST 2017
+#Fri Oct 26 18:01:31 CLST 2018
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-3.3-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-4.6-all.zip

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -6,32 +6,36 @@ import './pages/animated_map_controller.dart';
 import './pages/marker_anchor.dart';
 import './pages/plugin_api.dart';
 import './pages/polyline.dart';
+import './pages/polygon.dart';
+import './pages/circle.dart';
 import './pages/tap_to_add.dart';
 import './pages/offline_map.dart';
 import './pages/on_tap.dart';
 
-void main() => runApp(new MyApp());
+void main() => runApp(MyApp());
 
 class MyApp extends StatelessWidget {
   // This widget is the root of your application.
   @override
   Widget build(BuildContext context) {
-    return new MaterialApp(
+    return MaterialApp(
       title: 'Flutter Map Example',
-      theme: new ThemeData(
+      theme: ThemeData(
         primarySwatch: mapBoxBlue,
       ),
-      home: new HomePage(),
+      home: HomePage(),
       routes: <String, WidgetBuilder>{
-        TapToAddPage.route: (context) => new TapToAddPage(),
-        EsriPage.route: (context) => new EsriPage(),
-        PolylinePage.route: (context) => new PolylinePage(),
-        MapControllerPage.route: (context) => new MapControllerPage(),
-        AnimatedMapControllerPage.route: (context) => new AnimatedMapControllerPage(),
-        MarkerAnchorPage.route: (context) => new MarkerAnchorPage(),
-        PluginPage.route: (context) => new PluginPage(),
-        OfflineMapPage.route: (context) => new OfflineMapPage(),
-        OnTapPage.route: (context) => new OnTapPage(),
+        TapToAddPage.route: (context) => TapToAddPage(),
+        EsriPage.route: (context) => EsriPage(),
+        PolylinePage.route: (context) => PolylinePage(),
+        PolygonPage.route: (context) => PolygonPage(),
+        CirclePage.route: (context) => CirclePage(),
+        MapControllerPage.route: (context) => MapControllerPage(),
+        AnimatedMapControllerPage.route: (context) => AnimatedMapControllerPage(),
+        MarkerAnchorPage.route: (context) => MarkerAnchorPage(),
+        PluginPage.route: (context) => PluginPage(),
+        OfflineMapPage.route: (context) => OfflineMapPage(),
+        OnTapPage.route: (context) => OnTapPage(),
       },
     );
   }

--- a/example/lib/pages/animated_map_controller.dart
+++ b/example/lib/pages/animated_map_controller.dart
@@ -8,7 +8,7 @@ class AnimatedMapControllerPage extends StatefulWidget {
 
   @override
   AnimatedMapControllerPageState createState() {
-    return new AnimatedMapControllerPageState();
+    return AnimatedMapControllerPageState();
   }
 }
 
@@ -23,25 +23,25 @@ class AnimatedMapControllerPageState extends State<AnimatedMapControllerPage> wi
   // See https://github.com/flutter/flutter/issues/14317#issuecomment-361085869
   // This project didn't require that change, so YMMV.
 
-  static LatLng london = new LatLng(51.5, -0.09);
-  static LatLng paris = new LatLng(48.8566, 2.3522);
-  static LatLng dublin = new LatLng(53.3498, -6.2603);
+  static LatLng london = LatLng(51.5, -0.09);
+  static LatLng paris = LatLng(48.8566, 2.3522);
+  static LatLng dublin = LatLng(53.3498, -6.2603);
 
   MapController mapController;
 
   void initState() {
     super.initState();
-    mapController = new MapController();
+    mapController = MapController();
   }
 
   void _animatedMapMove (LatLng destLocation, double destZoom) {
     // Create some tweens. These serve to split up the transition from one location to another.
     // In our case, we want to split the transition be<tween> our current map center and the destination.
-    final _latTween = new Tween<double>(begin: mapController.center.latitude, end: destLocation.latitude);
-    final _lngTween = new Tween<double>(begin: mapController.center.longitude, end: destLocation.longitude);
-    final _zoomTween = new Tween<double>(begin: mapController.zoom, end: destZoom);
+    final _latTween = Tween<double>(begin: mapController.center.latitude, end: destLocation.latitude);
+    final _lngTween = Tween<double>(begin: mapController.center.longitude, end: destLocation.longitude);
+    final _zoomTween = Tween<double>(begin: mapController.zoom, end: destZoom);
 
-    // Create a new animation controller that has a duration and a TickerProvider.
+    // Create a animation controller that has a duration and a TickerProvider.
     AnimationController controller = AnimationController(duration: const Duration(milliseconds: 500), vsync: this);
     // The animation determines what path the animation will take. You can try different Curves values, although I found
     // fastOutSlowIn to be my favorite.
@@ -68,62 +68,62 @@ class AnimatedMapControllerPageState extends State<AnimatedMapControllerPage> wi
 
   Widget build(BuildContext context) {
     var markers = <Marker>[
-      new Marker(
+      Marker(
         width: 80.0,
         height: 80.0,
         point: london,
-        builder: (ctx) => new Container(
-          key: new Key("blue"),
-          child: new FlutterLogo(),
+        builder: (ctx) => Container(
+          key: Key("blue"),
+          child: FlutterLogo(),
         ),
       ),
-      new Marker(
+      Marker(
         width: 80.0,
         height: 80.0,
         point: dublin,
-        builder: (ctx) => new Container(
-          child: new FlutterLogo(
-            key: new Key("green"),
+        builder: (ctx) => Container(
+          child: FlutterLogo(
+            key: Key("green"),
             colors: Colors.green,
           ),
         ),
       ),
-      new Marker(
+      Marker(
         width: 80.0,
         height: 80.0,
         point: paris,
-        builder: (ctx) => new Container(
-          key: new Key("purple"),
-          child: new FlutterLogo(colors: Colors.purple),
+        builder: (ctx) => Container(
+          key: Key("purple"),
+          child: FlutterLogo(colors: Colors.purple),
         ),
       ),
     ];
 
-    return new Scaffold(
-      appBar: new AppBar(title: new Text("Animated MapController")),
+    return Scaffold(
+      appBar: AppBar(title: Text("Animated MapController")),
       drawer: buildDrawer(context, AnimatedMapControllerPage.route),
-      body: new Padding(
-        padding: new EdgeInsets.all(8.0),
-        child: new Column(
+      body: Padding(
+        padding: EdgeInsets.all(8.0),
+        child: Column(
           children: [
-            new Padding(
-              padding: new EdgeInsets.only(top: 8.0, bottom: 8.0),
-              child: new Row(
+            Padding(
+              padding: EdgeInsets.only(top: 8.0, bottom: 8.0),
+              child: Row(
                 children: <Widget>[
-                  new MaterialButton(
-                    child: new Text("London"),
+                  MaterialButton(
+                    child: Text("London"),
                     onPressed: () {
                       _animatedMapMove(london, 10.0);
                     },
                   ),
-                  new MaterialButton(
-                    child: new Text("Paris"),
+                  MaterialButton(
+                    child: Text("Paris"),
                     onPressed: () {
                       _animatedMapMove(paris, 5.0);
                     },
                   ),
-                  new MaterialButton(
-                    child: new Text("Dublin"),
+                  MaterialButton(
+                    child: Text("Dublin"),
                     onPressed: () {
                       _animatedMapMove(dublin, 5.0);
                     },
@@ -131,21 +131,21 @@ class AnimatedMapControllerPageState extends State<AnimatedMapControllerPage> wi
                 ],
               ),
             ),
-            new Padding(
-              padding: new EdgeInsets.only(top: 8.0, bottom: 8.0),
-              child: new Row(
+            Padding(
+              padding: EdgeInsets.only(top: 8.0, bottom: 8.0),
+              child: Row(
                 children: <Widget>[
-                  new MaterialButton(
-                    child: new Text("Fit Bounds"),
+                  MaterialButton(
+                    child: Text("Fit Bounds"),
                     onPressed: () {
-                      var bounds = new LatLngBounds();
+                      var bounds = LatLngBounds();
                       bounds.extend(dublin);
                       bounds.extend(paris);
                       bounds.extend(london);
                       mapController.fitBounds(
                         bounds,
-                        options: new FitBoundsOptions(
-                          padding: new Point<double>(30.0, 0.0),
+                        options: FitBoundsOptions(
+                          padding: Point<double>(30.0, 0.0),
                         ),
                       );
                     },
@@ -153,21 +153,21 @@ class AnimatedMapControllerPageState extends State<AnimatedMapControllerPage> wi
                 ],
               ),
             ),
-            new Flexible(
-              child: new FlutterMap(
+            Flexible(
+              child: FlutterMap(
                 mapController: mapController,
-                options: new MapOptions(
-                    center: new LatLng(51.5, -0.09),
+                options: MapOptions(
+                    center: LatLng(51.5, -0.09),
                     zoom: 5.0,
                     maxZoom: 5.0,
                     minZoom: 3.0
                 ),
                 layers: [
-                  new TileLayerOptions(
+                  TileLayerOptions(
                       urlTemplate:
                       "https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png",
                       subdomains: ['a', 'b', 'c']),
-                  new MarkerLayerOptions(markers: markers)
+                  MarkerLayerOptions(markers: markers)
                 ],
               ),
             ),

--- a/example/lib/pages/circle.dart
+++ b/example/lib/pages/circle.dart
@@ -1,0 +1,119 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_map/flutter_map.dart';
+import '../widgets/drawer.dart';
+import 'package:latlong/latlong.dart' hide Circle;
+
+class CirclePage extends StatefulWidget {
+  static const String route = "circle";
+  @override
+  State createState() => CirclePageState();
+}
+
+class CirclePageState extends State<CirclePage> {
+  String _eventMessage = "Tap on the map and its elements!";
+
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(title: Text("Circles")),
+      drawer: buildDrawer(context, CirclePage.route),
+      body: Padding(
+        padding: EdgeInsets.all(8.0),
+        child: Column(
+          children: [
+            Padding(
+              padding: EdgeInsets.only(top: 8.0, bottom: 8.0),
+              child: Text("Circles"),
+            ),
+            Text(
+              "$_eventMessage",
+              textAlign: TextAlign.center,
+            ),
+            Flexible(
+              child: FlutterMap(
+                options: MapOptions(
+                  center: LatLng(51.5, -0.09),
+                  zoom: 5.0,
+                  onTap: _handleMapTapped,
+                  onLongPress: _handleMapLongPressed,
+                ),
+                layers: [
+                  TileLayerOptions(
+                    urlTemplate:
+                        "https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png",
+                    subdomains: ['a', 'b', 'c'],
+                  ),
+                  CircleLayerOptions(
+                    circles: [
+                      CircleMarker(
+                        key: Key("zone_a"),
+                        center: LatLng(51.5, -0.09),
+                        borderStrokeWidth: 4.0,
+                        borderColor: Colors.purple,
+                        radius: 100000.0,
+                        color: Color(
+                            0x509C27B0), // Colors.purple with less opacity
+                      ),
+                      CircleMarker(
+                        key: Key("zone_b"),
+                        center: LatLng(53.3498, -6.2603),
+                        borderStrokeWidth: 4.0,
+                        borderColor: Colors.red,
+                        radius: 100000.0,
+                        color:
+                            Color(0x50F44336), // Colors.red with less opacity
+                      ),
+                      CircleMarker(
+                        key: Key("zone_c"),
+                        center: LatLng(48.8566, 2.3522),
+                        borderStrokeWidth: 4.0,
+                        borderColor: Colors.green,
+                        radius: 100000.0,
+                        color:
+                            Color(0x504CAF50), // Colors.green with less opacity
+                      ),
+                    ],
+                    onTap: _handleTap,
+                    onLongPress: _handleLongPress,
+                  ),
+                ],
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+
+  void _handleMapTapped(LatLng location) {
+    var message = "Map tapped at ${location.latitude}, ${location.longitude}";
+    print(message);
+    setState(() {
+      this._eventMessage = message;
+    });
+  }
+
+  void _handleMapLongPressed(LatLng location) {
+    var message =
+        "Map long pressed at ${location.latitude}, ${location.longitude}";
+    print(message);
+    setState(() {
+      this._eventMessage = message;
+    });
+  }
+
+  void _handleTap(CircleMarker circle, LatLng location) {
+    var message = "Tapped on circle #${circle.key}. LatLng = $location";
+    print(message);
+    setState(() {
+      this._eventMessage = message;
+    });
+  }
+
+  void _handleLongPress(CircleMarker circle, LatLng location) {
+    var message = "Long press on circle #${circle.key}. LatLng = $location";
+    print(message);
+    setState(() {
+      this._eventMessage = message;
+    });
+  }
+}

--- a/example/lib/pages/esri.dart
+++ b/example/lib/pages/esri.dart
@@ -8,25 +8,25 @@ class EsriPage extends StatelessWidget {
   static const String route = "esri";
 
   Widget build(BuildContext context) {
-    return new Scaffold(
-      appBar: new AppBar(title: new Text("Esri")),
+    return Scaffold(
+      appBar: AppBar(title: Text("Esri")),
       drawer: buildDrawer(context, TapToAddPage.route),
-      body: new Padding(
-        padding: new EdgeInsets.all(8.0),
-        child: new Column(
+      body: Padding(
+        padding: EdgeInsets.all(8.0),
+        child: Column(
           children: [
-            new Padding(
-              padding: new EdgeInsets.only(top: 8.0, bottom: 8.0),
-              child: new Text("Esri"),
+            Padding(
+              padding: EdgeInsets.only(top: 8.0, bottom: 8.0),
+              child: Text("Esri"),
             ),
-            new Flexible(
-              child: new FlutterMap(
-                options: new MapOptions(
-                  center: new LatLng(45.5231, -122.6765),
+            Flexible(
+              child: FlutterMap(
+                options: MapOptions(
+                  center: LatLng(45.5231, -122.6765),
                   zoom: 13.0,
                 ),
                 layers: [
-                  new TileLayerOptions(
+                  TileLayerOptions(
                     urlTemplate:
                     "https://server.arcgisonline.com/ArcGIS/rest/services/World_Street_Map/MapServer/tile/{z}/{y}/{x}",
                   ),

--- a/example/lib/pages/home.dart
+++ b/example/lib/pages/home.dart
@@ -7,57 +7,57 @@ class HomePage extends StatelessWidget {
   static const String route = '/';
   Widget build(BuildContext context) {
     var markers = <Marker>[
-      new Marker(
+      Marker(
         width: 80.0,
         height: 80.0,
-        point: new LatLng(51.5, -0.09),
-        builder: (ctx) => new Container(
-          child: new FlutterLogo(),
+        point: LatLng(51.5, -0.09),
+        builder: (ctx) => Container(
+          child: FlutterLogo(),
         ),
       ),
-      new Marker(
+      Marker(
         width: 80.0,
         height: 80.0,
-        point: new LatLng(53.3498, -6.2603),
-        builder: (ctx) => new Container(
-          child: new FlutterLogo(
+        point: LatLng(53.3498, -6.2603),
+        builder: (ctx) => Container(
+          child: FlutterLogo(
             colors: Colors.green,
           ),
         ),
       ),
-      new Marker(
+      Marker(
         width: 80.0,
         height: 80.0,
-        point: new LatLng(48.8566, 2.3522),
-        builder: (ctx) => new Container(
-          child: new FlutterLogo(colors: Colors.purple),
+        point: LatLng(48.8566, 2.3522),
+        builder: (ctx) => Container(
+          child: FlutterLogo(colors: Colors.purple),
         ),
       ),
     ];
 
-    return new Scaffold(
-      appBar: new AppBar(title: new Text("Home")),
+    return Scaffold(
+      appBar: AppBar(title: Text("Home")),
       drawer: buildDrawer(context, route),
-      body: new Padding(
-        padding: new EdgeInsets.all(8.0),
-        child: new Column(
+      body: Padding(
+        padding: EdgeInsets.all(8.0),
+        child: Column(
           children: [
-            new Padding(
-              padding: new EdgeInsets.only(top: 8.0, bottom: 8.0),
-              child: new Text("This is a map that is showing (51.5, -0.9)."),
+            Padding(
+              padding: EdgeInsets.only(top: 8.0, bottom: 8.0),
+              child: Text("This is a map that is showing (51.5, -0.9)."),
             ),
-            new Flexible(
-              child: new FlutterMap(
-                options: new MapOptions(
-                  center: new LatLng(51.5, -0.09),
+            Flexible(
+              child: FlutterMap(
+                options: MapOptions(
+                  center: LatLng(51.5, -0.09),
                   zoom: 5.0,
                 ),
                 layers: [
-                  new TileLayerOptions(
+                  TileLayerOptions(
                       urlTemplate:
                       "https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png",
                       subdomains: ['a', 'b', 'c']),
-                  new MarkerLayerOptions(markers: markers)
+                  MarkerLayerOptions(markers: markers)
                 ],
               ),
             ),

--- a/example/lib/pages/map_controller.dart
+++ b/example/lib/pages/map_controller.dart
@@ -8,82 +8,82 @@ class MapControllerPage extends StatefulWidget {
 
   @override
   MapControllerPageState createState() {
-    return new MapControllerPageState();
+    return MapControllerPageState();
   }
 }
 
 class MapControllerPageState extends State<MapControllerPage> {
-  final GlobalKey<ScaffoldState> _scaffoldKey = new GlobalKey<ScaffoldState>();
-  static LatLng london = new LatLng(51.5, -0.09);
-  static LatLng paris = new LatLng(48.8566, 2.3522);
-  static LatLng dublin = new LatLng(53.3498, -6.2603);
+  final GlobalKey<ScaffoldState> _scaffoldKey = GlobalKey<ScaffoldState>();
+  static LatLng london = LatLng(51.5, -0.09);
+  static LatLng paris = LatLng(48.8566, 2.3522);
+  static LatLng dublin = LatLng(53.3498, -6.2603);
 
   MapController mapController;
 
   void initState() {
     super.initState();
-    mapController = new MapController();
+    mapController = MapController();
   }
 
   Widget build(BuildContext context) {
     var markers = <Marker>[
-      new Marker(
+      Marker(
         width: 80.0,
         height: 80.0,
         point: london,
-        builder: (ctx) => new Container(
-              key: new Key("blue"),
-              child: new FlutterLogo(),
+        builder: (ctx) => Container(
+              key: Key("blue"),
+              child: FlutterLogo(),
             ),
       ),
-      new Marker(
+      Marker(
         width: 80.0,
         height: 80.0,
         point: dublin,
-        builder: (ctx) => new Container(
-              child: new FlutterLogo(
-                key: new Key("green"),
+        builder: (ctx) => Container(
+              child: FlutterLogo(
+                key: Key("green"),
                 colors: Colors.green,
               ),
             ),
       ),
-      new Marker(
+      Marker(
         width: 80.0,
         height: 80.0,
         point: paris,
-        builder: (ctx) => new Container(
-              key: new Key("purple"),
-              child: new FlutterLogo(colors: Colors.purple),
+        builder: (ctx) => Container(
+              key: Key("purple"),
+              child: FlutterLogo(colors: Colors.purple),
             ),
       ),
     ];
 
-    return new Scaffold(
+    return Scaffold(
       key: _scaffoldKey,
-      appBar: new AppBar(title: new Text("MapController")),
+      appBar: AppBar(title: Text("MapController")),
       drawer: buildDrawer(context, MapControllerPage.route),
-      body: new Padding(
-        padding: new EdgeInsets.all(8.0),
-        child: new Column(
+      body: Padding(
+        padding: EdgeInsets.all(8.0),
+        child: Column(
           children: [
-            new Padding(
-              padding: new EdgeInsets.only(top: 8.0, bottom: 8.0),
-              child: new Row(
+            Padding(
+              padding: EdgeInsets.only(top: 8.0, bottom: 8.0),
+              child: Row(
                 children: <Widget>[
-                  new MaterialButton(
-                    child: new Text("London"),
+                  MaterialButton(
+                    child: Text("London"),
                     onPressed: () {
                       mapController.move(london, 18.0);
                     },
                   ),
-                  new MaterialButton(
-                    child: new Text("Paris"),
+                  MaterialButton(
+                    child: Text("Paris"),
                     onPressed: () {
                       mapController.move(paris, 5.0);
                     },
                   ),
-                  new MaterialButton(
-                    child: new Text("Dublin"),
+                  MaterialButton(
+                    child: Text("Dublin"),
                     onPressed: () {
                       mapController.move(dublin, 5.0);
                     },
@@ -91,32 +91,32 @@ class MapControllerPageState extends State<MapControllerPage> {
                 ],
               ),
             ),
-            new Padding(
-              padding: new EdgeInsets.only(top: 8.0, bottom: 8.0),
-              child: new Row(
+            Padding(
+              padding: EdgeInsets.only(top: 8.0, bottom: 8.0),
+              child: Row(
                 children: <Widget>[
-                  new MaterialButton(
-                    child: new Text("Fit Bounds"),
+                  MaterialButton(
+                    child: Text("Fit Bounds"),
                     onPressed: () {
-                      var bounds = new LatLngBounds();
+                      var bounds = LatLngBounds();
                       bounds.extend(dublin);
                       bounds.extend(paris);
                       bounds.extend(london);
                       mapController.fitBounds(
                         bounds,
-                        options: new FitBoundsOptions(
-                          padding: new Point<double>(30.0, 0.0),
+                        options: FitBoundsOptions(
+                          padding: Point<double>(30.0, 0.0),
                         ),
                       );
                     },
                   ),
-                  new MaterialButton(
-                    child: new Text("Get Bounds"),
+                  MaterialButton(
+                    child: Text("Get Bounds"),
                     onPressed: () {
                       final bounds = mapController.bounds;
 
-                      _scaffoldKey.currentState.showSnackBar(new SnackBar(
-                        content: new Text(
+                      _scaffoldKey.currentState.showSnackBar(SnackBar(
+                        content: Text(
                           'Map bounds: \n'
                               'E: ${bounds.east} \n'
                               'N: ${bounds.north} \n'
@@ -129,21 +129,21 @@ class MapControllerPageState extends State<MapControllerPage> {
                 ],
               ),
             ),
-            new Flexible(
-              child: new FlutterMap(
+            Flexible(
+              child: FlutterMap(
                 mapController: mapController,
-                options: new MapOptions(
-                  center: new LatLng(51.5, -0.09),
+                options: MapOptions(
+                  center: LatLng(51.5, -0.09),
                   zoom: 5.0,
                   maxZoom: 5.0,
                   minZoom: 3.0,
                 ),
                 layers: [
-                  new TileLayerOptions(
+                  TileLayerOptions(
                       urlTemplate:
                           "https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png",
                       subdomains: ['a', 'b', 'c']),
-                  new MarkerLayerOptions(markers: markers)
+                  MarkerLayerOptions(markers: markers)
                 ],
               ),
             ),

--- a/example/lib/pages/marker_anchor.dart
+++ b/example/lib/pages/marker_anchor.dart
@@ -7,7 +7,7 @@ class MarkerAnchorPage extends StatefulWidget {
   static const String route = '/marker_anchors';
   @override
   MarkerAnchorPageState createState() {
-    return new MarkerAnchorPageState();
+    return MarkerAnchorPageState();
   }
 }
 
@@ -23,76 +23,76 @@ class MarkerAnchorPageState extends State<MarkerAnchorPage> {
 
   Widget build(BuildContext context) {
     var markers = <Marker>[
-      new Marker(
+      Marker(
           width: 80.0,
           height: 80.0,
-          point: new LatLng(51.5, -0.09),
-          builder: (ctx) => new Container(
-            child: new FlutterLogo(),
+          point: LatLng(51.5, -0.09),
+          builder: (ctx) => Container(
+            child: FlutterLogo(),
           ),
           anchor: anchorPos,
           anchorOverride: anchorOverride),
-      new Marker(
+      Marker(
           width: 80.0,
           height: 80.0,
-          point: new LatLng(53.3498, -6.2603),
-          builder: (ctx) => new Container(
-            child: new FlutterLogo(
+          point: LatLng(53.3498, -6.2603),
+          builder: (ctx) => Container(
+            child: FlutterLogo(
               colors: Colors.green,
             ),
           ),
           anchor: anchorPos,
           anchorOverride: anchorOverride),
-      new Marker(
+      Marker(
           width: 80.0,
           height: 80.0,
-          point: new LatLng(48.8566, 2.3522),
-          builder: (ctx) => new Container(
-            child: new FlutterLogo(colors: Colors.purple),
+          point: LatLng(48.8566, 2.3522),
+          builder: (ctx) => Container(
+            child: FlutterLogo(colors: Colors.purple),
           ),
           anchor: anchorPos,
           anchorOverride: anchorOverride),
     ];
 
-    return new Scaffold(
-      appBar: new AppBar(title: new Text("Marker Anchor Points")),
+    return Scaffold(
+      appBar: AppBar(title: Text("Marker Anchor Points")),
       drawer: buildDrawer(context, MarkerAnchorPage.route),
-      body: new Padding(
-        padding: new EdgeInsets.all(8.0),
-        child: new Column(
+      body: Padding(
+        padding: EdgeInsets.all(8.0),
+        child: Column(
           children: [
-            new Padding(
-              padding: new EdgeInsets.only(top: 8.0, bottom: 8.0),
-              child: new Text(
+            Padding(
+              padding: EdgeInsets.only(top: 8.0, bottom: 8.0),
+              child: Text(
                   "Markers can be anchored to the top, bottom, left or right."),
             ),
-            new Padding(
-              padding: new EdgeInsets.only(top: 8.0, bottom: 8.0),
-              child: new Row(
+            Padding(
+              padding: EdgeInsets.only(top: 8.0, bottom: 8.0),
+              child: Row(
                 children: <Widget>[
-                  new MaterialButton(
-                    child: new Text("Left"),
+                  MaterialButton(
+                    child: Text("Left"),
                     onPressed: () => setState(() {
                       anchorPos = AnchorPos.left;
                       anchorOverride = null;
                     }),
                   ),
-                  new MaterialButton(
-                    child: new Text("Right"),
+                  MaterialButton(
+                    child: Text("Right"),
                     onPressed: () => setState(() {
                       anchorPos = AnchorPos.right;
                       anchorOverride = null;
                     }),
                   ),
-                  new MaterialButton(
-                    child: new Text("Top"),
+                  MaterialButton(
+                    child: Text("Top"),
                     onPressed: () => setState(() {
                       anchorPos = AnchorPos.top;
                       anchorOverride = null;
                     }),
                   ),
-                  new MaterialButton(
-                    child: new Text("Bottom"),
+                  MaterialButton(
+                    child: Text("Bottom"),
                     onPressed: () => setState(() {
                       anchorPos = AnchorPos.bottom;
                       anchorOverride = null;
@@ -101,40 +101,40 @@ class MarkerAnchorPageState extends State<MarkerAnchorPage> {
                 ],
               ),
             ),
-            new Padding(
-              padding: new EdgeInsets.only(top: 8.0, bottom: 8.0),
-              child: new Row(
+            Padding(
+              padding: EdgeInsets.only(top: 8.0, bottom: 8.0),
+              child: Row(
                 children: <Widget>[
-                  new MaterialButton(
-                    child: new Text("Center"),
+                  MaterialButton(
+                    child: Text("Center"),
                     onPressed: () => setState(() {
                       anchorPos = AnchorPos.center;
                       anchorOverride = null;
                     }),
                   ),
-                  new MaterialButton(
-                    child: new Text("Custom"),
+                  MaterialButton(
+                    child: Text("Custom"),
                     onPressed: () => setState(
                           () {
-                        anchorOverride = new Anchor(80.0, 80.0);
+                        anchorOverride = Anchor(80.0, 80.0);
                       },
                     ),
                   ),
                 ],
               ),
             ),
-            new Flexible(
-              child: new FlutterMap(
-                options: new MapOptions(
-                  center: new LatLng(51.5, -0.09),
+            Flexible(
+              child: FlutterMap(
+                options: MapOptions(
+                  center: LatLng(51.5, -0.09),
                   zoom: 5.0,
                 ),
                 layers: [
-                  new TileLayerOptions(
+                  TileLayerOptions(
                       urlTemplate:
                       "https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png",
                       subdomains: ['a', 'b', 'c']),
-                  new MarkerLayerOptions(markers: markers)
+                  MarkerLayerOptions(markers: markers)
                 ],
               ),
             ),

--- a/example/lib/pages/offline_map.dart
+++ b/example/lib/pages/offline_map.dart
@@ -6,22 +6,22 @@ import 'package:latlong/latlong.dart';
 class OfflineMapPage extends StatelessWidget {
   static const String route = '/offline_map';
   Widget build(BuildContext context) {
-    return new Scaffold(
-      appBar: new AppBar(title: new Text("Offline Map")),
+    return Scaffold(
+      appBar: AppBar(title: Text("Offline Map")),
       drawer: buildDrawer(context, route),
-      body: new Padding(
-        padding: new EdgeInsets.all(8.0),
-        child: new Column(
+      body: Padding(
+        padding: EdgeInsets.all(8.0),
+        child: Column(
           children: [
-            new Padding(
-              padding: new EdgeInsets.only(top: 8.0, bottom: 8.0),
-              child: new Text(
+            Padding(
+              padding: EdgeInsets.only(top: 8.0, bottom: 8.0),
+              child: Text(
                   "This is an offline map that is showing Anholt Island, Denmark."),
             ),
-            new Flexible(
-              child: new FlutterMap(
-                options: new MapOptions(
-                  center: new LatLng(56.704173, 11.543808),
+            Flexible(
+              child: FlutterMap(
+                options: MapOptions(
+                  center: LatLng(56.704173, 11.543808),
                   minZoom: 12.0,
                   maxZoom: 14.0,
                   zoom: 13.0,
@@ -29,7 +29,7 @@ class OfflineMapPage extends StatelessWidget {
                   nePanBoundary: LatLng(56.7378, 11.6644),
                 ),
                 layers: [
-                  new TileLayerOptions(
+                  TileLayerOptions(
                     offlineMode: true,
                     maxZoom: 14.0,
                     urlTemplate: "assets/map/anholt_osmbright/{z}/{x}/{y}.png",

--- a/example/lib/pages/on_tap.dart
+++ b/example/lib/pages/on_tap.dart
@@ -8,90 +8,90 @@ class OnTapPage extends StatefulWidget {
 
   @override
   OnTapPageState createState() {
-    return new OnTapPageState();
+    return OnTapPageState();
   }
 }
 
 class OnTapPageState extends State<OnTapPage> {
-  final GlobalKey<ScaffoldState> _scaffoldKey = new GlobalKey<ScaffoldState>();
-  static LatLng london = new LatLng(51.5, -0.09);
-  static LatLng paris = new LatLng(48.8566, 2.3522);
-  static LatLng dublin = new LatLng(53.3498, -6.2603);
+  final GlobalKey<ScaffoldState> _scaffoldKey = GlobalKey<ScaffoldState>();
+  static LatLng london = LatLng(51.5, -0.09);
+  static LatLng paris = LatLng(48.8566, 2.3522);
+  static LatLng dublin = LatLng(53.3498, -6.2603);
 
   Widget build(BuildContext context) {
     var markers = <Marker>[
-      new Marker(
+      Marker(
         width: 80.0,
         height: 80.0,
         point: london,
-        builder: (ctx) => new Container(
-                child: new GestureDetector(
+        builder: (ctx) => Container(
+                child: GestureDetector(
               onTap: () {
-                _scaffoldKey.currentState.showSnackBar(new SnackBar(
-                  content: new Text("Tapped on blue FlutterLogo Marker"),
+                _scaffoldKey.currentState.showSnackBar(SnackBar(
+                  content: Text("Tapped on blue FlutterLogo Marker"),
                 ));
               },
-              child: new FlutterLogo(),
+              child: FlutterLogo(),
             )),
       ),
-      new Marker(
+      Marker(
         width: 80.0,
         height: 80.0,
         point: dublin,
-        builder: (ctx) => new Container(
-                child: new GestureDetector(
+        builder: (ctx) => Container(
+                child: GestureDetector(
               onTap: () {
-                _scaffoldKey.currentState.showSnackBar(new SnackBar(
-                  content: new Text("Tapped on green FlutterLogo Marker"),
+                _scaffoldKey.currentState.showSnackBar(SnackBar(
+                  content: Text("Tapped on green FlutterLogo Marker"),
                 ));
               },
-              child: new FlutterLogo(
+              child: FlutterLogo(
                 colors: Colors.green,
               ),
             )),
       ),
-      new Marker(
+      Marker(
         width: 80.0,
         height: 80.0,
         point: paris,
-        builder: (ctx) => new Container(
-                child: new GestureDetector(
+        builder: (ctx) => Container(
+                child: GestureDetector(
               onTap: () {
-                _scaffoldKey.currentState.showSnackBar(new SnackBar(
-                  content: new Text("Tapped on purple FlutterLogo Marker"),
+                _scaffoldKey.currentState.showSnackBar(SnackBar(
+                  content: Text("Tapped on purple FlutterLogo Marker"),
                 ));
               },
-              child: new FlutterLogo(colors: Colors.purple),
+              child: FlutterLogo(colors: Colors.purple),
             )),
       ),
     ];
 
-    return new Scaffold(
+    return Scaffold(
       key: _scaffoldKey,
-      appBar: new AppBar(title: new Text("OnTap")),
+      appBar: AppBar(title: Text("OnTap")),
       drawer: buildDrawer(context, OnTapPage.route),
-      body: new Padding(
-        padding: new EdgeInsets.all(8.0),
-        child: new Column(
+      body: Padding(
+        padding: EdgeInsets.all(8.0),
+        child: Column(
           children: [
-            new Padding(
-              padding: new EdgeInsets.only(top: 8.0, bottom: 8.0),
-              child: new Text("Try tapping on the markers"),
+            Padding(
+              padding: EdgeInsets.only(top: 8.0, bottom: 8.0),
+              child: Text("Try tapping on the markers"),
             ),
-            new Flexible(
-              child: new FlutterMap(
-                options: new MapOptions(
-                  center: new LatLng(51.5, -0.09),
+            Flexible(
+              child: FlutterMap(
+                options: MapOptions(
+                  center: LatLng(51.5, -0.09),
                   zoom: 5.0,
                   maxZoom: 5.0,
                   minZoom: 3.0,
                 ),
                 layers: [
-                  new TileLayerOptions(
+                  TileLayerOptions(
                       urlTemplate:
                           "https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png",
                       subdomains: ['a', 'b', 'c']),
-                  new MarkerLayerOptions(markers: markers)
+                  MarkerLayerOptions(markers: markers)
                 ],
               ),
             ),

--- a/example/lib/pages/plugin_api.dart
+++ b/example/lib/pages/plugin_api.dart
@@ -7,28 +7,28 @@ class PluginPage extends StatelessWidget {
   static const String route = "plugins";
 
   Widget build(BuildContext context) {
-    return new Scaffold(
-      appBar: new AppBar(title: new Text("Plugins")),
+    return Scaffold(
+      appBar: AppBar(title: Text("Plugins")),
       drawer: buildDrawer(context, PluginPage.route),
-      body: new Padding(
-        padding: new EdgeInsets.all(8.0),
-        child: new Column(
+      body: Padding(
+        padding: EdgeInsets.all(8.0),
+        child: Column(
           children: [
-            new Flexible(
-              child: new FlutterMap(
-                options: new MapOptions(
-                  center: new LatLng(51.5, -0.09),
+            Flexible(
+              child: FlutterMap(
+                options: MapOptions(
+                  center: LatLng(51.5, -0.09),
                   zoom: 5.0,
                   plugins: [
-                    new MyCustomPlugin(),
+                    MyCustomPlugin(),
                   ],
                 ),
                 layers: [
-                  new TileLayerOptions(
+                  TileLayerOptions(
                       urlTemplate:
                           "https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png",
                       subdomains: ['a', 'b', 'c']),
-                  new MyCustomPluginOptions(text: "I'm a plugin!"),
+                  MyCustomPluginOptions(text: "I'm a plugin!"),
                 ],
               ),
             ),
@@ -48,12 +48,12 @@ class MyCustomPlugin implements MapPlugin {
   @override
   Widget createLayer(LayerOptions options, MapState mapState, Stream<Null> stream) {
     if (options is MyCustomPluginOptions) {
-      var style = new TextStyle(
+      var style = TextStyle(
         fontWeight: FontWeight.bold,
         fontSize: 24.0,
         color: Colors.red,
       );
-      return new Text(
+      return Text(
         options.text,
         style: style,
       );

--- a/example/lib/pages/polygon.dart
+++ b/example/lib/pages/polygon.dart
@@ -3,13 +3,13 @@ import 'package:flutter_map/flutter_map.dart';
 import '../widgets/drawer.dart';
 import 'package:latlong/latlong.dart';
 
-class PolylinePage extends StatefulWidget {
-  static const String route = "polyline";
+class PolygonPage extends StatefulWidget {
+  static const String route = "polygon";
   @override
-  State createState() => PolylinePageState();
+  State createState() => PolygonPageState();
 }
 
-class PolylinePageState extends State<PolylinePage> {
+class PolygonPageState extends State<PolygonPage> {
   String _eventMessage = "Tap on the map and its elements!";
 
   Widget build(BuildContext context) {
@@ -24,15 +24,15 @@ class PolylinePageState extends State<PolylinePage> {
       LatLng(53.215497, 6.564996),
     ];
     return Scaffold(
-      appBar: AppBar(title: Text("Polylines")),
-      drawer: buildDrawer(context, PolylinePage.route),
+      appBar: AppBar(title: Text("Polygons")),
+      drawer: buildDrawer(context, PolygonPage.route),
       body: Padding(
         padding: EdgeInsets.all(8.0),
         child: Column(
           children: [
             Padding(
               padding: EdgeInsets.only(top: 8.0, bottom: 8.0),
-              child: Text("Polylines"),
+              child: Text("Polygons"),
             ),
             Text(
               "$_eventMessage",
@@ -48,25 +48,29 @@ class PolylinePageState extends State<PolylinePage> {
                 ),
                 layers: [
                   TileLayerOptions(
-                      urlTemplate:
-                          "https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png",
-                      subdomains: ['a', 'b', 'c']),
-                  PolylineLayerOptions(
-                    polylines: [
-                      Polyline(
-                        key: Key("route_a"),
+                    urlTemplate:
+                        "https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png",
+                    subdomains: ['a', 'b', 'c'],
+                  ),
+                  PolygonLayerOptions(
+                    polygons: [
+                      Polygon(
+                        key: Key("zone_a"),
                         points: pointsA,
-                        strokeWidth: 10.0,
-                        color: Colors.purple,
-                        isDotted: true,
+                        //borderStrokeWidth: 4.0,
+                        borderColor: Colors.purple,
+                        closeFigure: true,
+                        color: Color(
+                            0x509C27B0), // Colors.purple with less opacity
                       ),
-                      Polyline(
-                        key: Key("route_b"),
+                      Polygon(
+                        key: Key("zone_b"),
                         points: pointsB,
-                        strokeWidth: 10.0,
-                        color: Colors.red,
-                        displayPoints: true,
-                        pointsWidth: 8.0,
+                        borderStrokeWidth: 4.0,
+                        borderColor: Colors.red,
+                        closeFigure: true,
+                        color:
+                            Color(0x50F44336), // Colors.red with less opacity
                       ),
                     ],
                     onTap: _handleTap,
@@ -98,16 +102,16 @@ class PolylinePageState extends State<PolylinePage> {
     });
   }
 
-  void _handleTap(Polyline polyline, LatLng location) {
-    var message = "Tapped on polyline #${polyline.key}. LatLng = $location";
+  void _handleTap(Polygon polygon, LatLng location) {
+    var message = "Tapped on polygon #${polygon.key}. LatLng = $location";
     print(message);
     setState(() {
       this._eventMessage = message;
     });
   }
 
-  void _handleLongPress(Polyline polyline, LatLng location) {
-    var message = "Long Press on polyline #${polyline.key}. LatLng = $location";
+  void _handleLongPress(Polygon polygon, LatLng location) {
+    var message = "Long press on polygon #${polygon.key}. LatLng = $location";
     print(message);
     setState(() {
       this._eventMessage = message;

--- a/example/lib/pages/tap_to_add.dart
+++ b/example/lib/pages/tap_to_add.dart
@@ -8,7 +8,7 @@ class TapToAddPage extends StatefulWidget {
   static const String route = '/tap';
 
   State<StatefulWidget> createState() {
-    return new TapToAddPageState();
+    return TapToAddPageState();
   }
 }
 
@@ -17,39 +17,39 @@ class TapToAddPageState extends State<TapToAddPage> {
 
   Widget build(BuildContext context) {
     var markers = tappedPoints.map((latlng) {
-      return new Marker(
+      return Marker(
         width: 80.0,
         height: 80.0,
         point: latlng,
-        builder: (ctx) => new Container(
-          child: new FlutterLogo(),
+        builder: (ctx) => Container(
+          child: FlutterLogo(),
         ),
       );
     }).toList();
 
-    return new Scaffold(
-      appBar: new AppBar(title: new Text("Tap to add pins")),
+    return Scaffold(
+      appBar: AppBar(title: Text("Tap to add pins")),
       drawer: buildDrawer(context, TapToAddPage.route),
-      body: new Padding(
-        padding: new EdgeInsets.all(8.0),
-        child: new Column(
+      body: Padding(
+        padding: EdgeInsets.all(8.0),
+        child: Column(
           children: [
-            new Padding(
-              padding: new EdgeInsets.only(top: 8.0, bottom: 8.0),
-              child: new Text("Tap to add pins"),
+            Padding(
+              padding: EdgeInsets.only(top: 8.0, bottom: 8.0),
+              child: Text("Tap to add pins"),
             ),
-            new Flexible(
-              child: new FlutterMap(
-                options: new MapOptions(
-                    center: new LatLng(45.5231, -122.6765),
+            Flexible(
+              child: FlutterMap(
+                options: MapOptions(
+                    center: LatLng(45.5231, -122.6765),
                     zoom: 13.0,
                     onTap: _handleTap),
                 layers: [
-                  new TileLayerOptions(
+                  TileLayerOptions(
                     urlTemplate:
                     "https://tile.openstreetmap.org/{z}/{x}/{y}.png",
                   ),
-                  new MarkerLayerOptions(markers: markers)
+                  MarkerLayerOptions(markers: markers)
                 ],
               ),
             ),

--- a/example/lib/widgets/drawer.dart
+++ b/example/lib/widgets/drawer.dart
@@ -7,82 +7,97 @@ import '../pages/marker_anchor.dart';
 import '../pages/offline_map.dart';
 import '../pages/plugin_api.dart';
 import '../pages/polyline.dart';
+import '../pages/polygon.dart';
+import '../pages/circle.dart';
 import '../pages/tap_to_add.dart';
 import '../pages/on_tap.dart';
 
 Drawer buildDrawer(BuildContext context, String currentRoute) {
-  return new Drawer(
-    child: new ListView(
+  return Drawer(
+    child: ListView(
       children: <Widget>[
         const DrawerHeader(
           child: const Center(
             child: const Text("Flutter Map Examples"),
           ),
         ),
-        new ListTile(
+        ListTile(
           title: const Text('OpenStreetMap'),
           selected: currentRoute == HomePage.route,
           onTap: () {
             Navigator.pushReplacementNamed(context, HomePage.route);
           },
         ),
-        new ListTile(
+        ListTile(
           title: const Text('Add Pins'),
           selected: currentRoute == TapToAddPage.route,
           onTap: () {
             Navigator.pushReplacementNamed(context, TapToAddPage.route);
           },
         ),
-        new ListTile(
+        ListTile(
           title: const Text('Esri'),
           selected: currentRoute == EsriPage.route,
           onTap: () {
             Navigator.pushReplacementNamed(context, EsriPage.route);
           },
         ),
-        new ListTile(
+        ListTile(
           title: const Text('Polylines'),
           selected: currentRoute == PolylinePage.route,
           onTap: () {
-            Navigator.pushReplacementNamed(context, PolylinePage.route);
+            Navigator.popAndPushNamed(context, PolylinePage.route);
           },
         ),
-        new ListTile(
+        ListTile(
+          title: const Text('Polygons'),
+          selected: currentRoute == PolygonPage.route,
+          onTap: () {
+            Navigator.popAndPushNamed(context, PolygonPage.route);
+          },
+        ),ListTile(
+          title: const Text('Circles'),
+          selected: currentRoute == CirclePage.route,
+          onTap: () {
+            Navigator.popAndPushNamed(context, CirclePage.route);
+          },
+        ),
+        ListTile(
           title: const Text('MapController'),
           selected: currentRoute == MapControllerPage.route,
           onTap: () {
             Navigator.pushReplacementNamed(context, MapControllerPage.route);
           },
         ),
-        new ListTile(
+        ListTile(
           title: const Text('Animated MapController'),
           selected: currentRoute == AnimatedMapControllerPage.route,
           onTap: () {
             Navigator.pushReplacementNamed(context, AnimatedMapControllerPage.route);
           },
         ),
-        new ListTile(
+        ListTile(
           title: const Text('Marker Anchors'),
           selected: currentRoute == MarkerAnchorPage.route,
           onTap: () {
             Navigator.pushReplacementNamed(context, MarkerAnchorPage.route);
           },
         ),
-        new ListTile(
+        ListTile(
           title: const Text('Plugins'),
           selected: currentRoute == PluginPage.route,
           onTap: () {
             Navigator.pushReplacementNamed(context, PluginPage.route);
           },
         ),
-        new ListTile(
+        ListTile(
           title: const Text('Offline Map'),
           selected: currentRoute == OfflineMapPage.route,
           onTap: () {
             Navigator.pushReplacementNamed(context, OfflineMapPage.route);
           },
         ),
-        new ListTile(
+        ListTile(
           title: const Text('OnTap'),
           selected: currentRoute == OnTapPage.route,
           onTap: () {

--- a/lib/flutter_map.dart
+++ b/lib/flutter_map.dart
@@ -47,10 +47,10 @@ class FlutterMap extends StatefulWidget {
     @required this.options,
     this.layers,
     MapController mapController,
-  })  : _mapController = mapController ?? new MapController(),
+  })  : _mapController = mapController ?? MapController(),
         super(key: key);
 
-  FlutterMapState createState() => new FlutterMapState(_mapController);
+  FlutterMapState createState() => FlutterMapState(_mapController);
 }
 
 abstract class MapController {
@@ -66,7 +66,7 @@ abstract class MapController {
   LatLngBounds get bounds;
   double get zoom;
 
-  factory MapController() => new MapControllerImpl();
+  factory MapController() => MapControllerImpl();
 }
 
 typedef TapCallback(LatLng point);
@@ -81,6 +81,7 @@ class MapOptions {
   final bool debug;
   final bool interactive;
   final TapCallback onTap;
+  final TapCallback onLongPress;
   final PositionCallback onPositionChanged;
   final List<MapPlugin> plugins;
   LatLng center;
@@ -97,12 +98,13 @@ class MapOptions {
     this.debug = false,
     this.interactive = true,
     this.onTap,
+    this.onLongPress,
     this.onPositionChanged,
     this.plugins = const [],
     this.swPanBoundary,
     this.nePanBoundary,
   }) {
-    if (center == null) center = new LatLng(50.5, 30.51);
+    if (center == null) center = LatLng(50.5, 30.51);
     assert(!isOutOfBounds(center)); //You cannot start outside pan boundary
   }
 

--- a/lib/src/core/bounds.dart
+++ b/lib/src/core/bounds.dart
@@ -6,7 +6,7 @@ class Bounds<T extends num> {
   final Point<T> max;
 
   factory Bounds(Point<T> a, Point<T> b) {
-    var bounds1 = new Bounds._(a, b);
+    var bounds1 = Bounds._(a, b);
     var bounds2 = bounds1.extend(a);
     return bounds2.extend(b);
   }
@@ -24,21 +24,21 @@ class Bounds<T extends num> {
       var maxX = math.max(point.x, this.max.x);
       var minY = math.min(point.y, this.min.y);
       var maxY = math.max(point.y, this.max.y);
-      newMin = new Point(minX, minY);
-      newMax = new Point(maxX, maxY);
+      newMin = Point(minX, minY);
+      newMax = Point(maxX, maxY);
     }
-    return new Bounds._(newMin, newMax);
+    return Bounds._(newMin, newMax);
   }
 
   Point<double> getCenter() {
-    return new Point<double>(
+    return Point<double>(
       (min.x + max.x) / 2,
       (min.y + max.y) / 2,
     );
   }
 
-  Point<T> get bottomLeft => new Point(min.x, max.y);
-  Point<T> get topRight => new Point(max.x, min.y);
+  Point<T> get bottomLeft => Point(min.x, max.y);
+  Point<T> get topRight => Point(max.x, min.y);
   Point<T> get topLeft => min;
   Point<T> get bottomRight => max;
 
@@ -49,7 +49,7 @@ class Bounds<T extends num> {
   bool contains(Point<T> point) {
     var min = point;
     var max = point;
-    return containsBounds(new Bounds(min, max));
+    return containsBounds(Bounds(min, max));
   }
 
   bool containsBounds(Bounds<T> b) {

--- a/lib/src/core/location_utils.dart
+++ b/lib/src/core/location_utils.dart
@@ -1,0 +1,339 @@
+import 'dart:math';
+import 'package:latlong/latlong.dart';
+import 'package:flutter_map/src/core/util.dart';
+
+class LocationUtils {
+  /// Computes if the given point is in the path of the polyline.
+  /// * [point] to evalute in the polyline.
+  /// * [linePoints] the points of the polyline.
+  /// * [toleratedDistance] the distance tolerated from the point to the line.
+  static bool isPointInPolyline(
+    LatLng point,
+    List<LatLng> linePoints, {
+    double toleratedDistance = 0.1,
+  }) {
+    double distance = 0.0;
+    if (linePoints.isNotEmpty) {
+      if (linePoints.length > 2) {
+        List<List<LatLng>> list = [];
+        for (int i = 0; i < linePoints.length - 1; i++) {
+          list.add([linePoints[i], linePoints[(i + 1)]]);
+        }
+        for (var sublist in list) {
+          LatLng vertex1 = sublist[0];
+          LatLng vertex2 = sublist[1];
+          double distanceToLine =
+              LocationUtils.distanceToLine(point, vertex1, vertex2);
+          distance = (distance == 0.0)
+              ? distanceToLine
+              : (distanceToLine < distance ? distanceToLine : distance);
+          if (distance <= toleratedDistance) {
+            return true;
+          }
+        }
+      } else if (linePoints.length == 1) {
+        distance = LocationUtils.distanceBetween(linePoints[0], point);
+        if (distance <= toleratedDistance) {
+          return true;
+        }
+      }
+    }
+    return false;
+  }
+
+  /// Calculates the nearest point in a line represented by ([vertexA], [vertexB])
+  /// from a [point] and Returns the distance in meters between the line and the [point].
+  static double distanceToLine(
+      final LatLng point, final LatLng vertexA, final LatLng vertexB) {
+    if (vertexA == vertexB) {
+      return distanceBetween(vertexB, point);
+    }
+    final double s0lat = degToRadian(point.latitude);
+    final double s0lng = degToRadian(point.longitude);
+    final double s1lat = degToRadian(vertexA.latitude);
+    final double s1lng = degToRadian(vertexA.longitude);
+    final double s2lat = degToRadian(vertexB.latitude);
+    final double s2lng = degToRadian(vertexB.longitude);
+
+    double s2s1lat = s2lat - s1lat;
+    double s2s1lng = s2lng - s1lng;
+    final double u = ((s0lat - s1lat) * s2s1lat + (s0lng - s1lng) * s2s1lng) /
+        (s2s1lat * s2s1lat + s2s1lng * s2s1lng);
+    if (u <= 0) {
+      return distanceBetween(point, vertexA);
+    }
+    if (u >= 1) {
+      return distanceBetween(point, vertexB);
+    }
+    LatLng sa = LatLng(
+      (point.latitude - vertexA.latitude),
+      (point.longitude - vertexA.longitude),
+    );
+    LatLng sb = LatLng(
+      (u * (vertexB.latitude - vertexA.latitude)),
+      (u * (vertexB.longitude - vertexA.longitude)),
+    );
+    return distanceBetween(sa, sb);
+  }
+
+  /// Computes the distance between two points.
+  /// * [pointA] first point.
+  /// * [pointB] second point.
+  ///
+  /// Returns the distance between the points in meters.
+  ///
+  /// Transcribed to dartlang from PolyUtil.java from android-maps-utils library by Google.
+  /// https://github.com/googlemaps/android-maps-utils
+  static double distanceBetween(LatLng pointA, LatLng pointB) {
+    int maximeters = 20;
+    // Convert lat/long to radians
+    double lat1 = pointA.latitude;
+    double lon1 = pointA.longitude;
+    double lat2 = pointB.latitude;
+    double lon2 = pointB.longitude;
+    lat1 *= pi / 180.0;
+    lat2 *= pi / 180.0;
+    lon1 *= pi / 180.0;
+    lon2 *= pi / 180.0;
+    double a = 6378137.0; // WGS84 major axis
+    double b = 6356752.3142; // WGS84 semi-major axis
+    double f = (a - b) / a;
+    double aSqMinusBSqOverBSq = (a * a - b * b) / (b * b);
+    double L = lon2 - lon1;
+    double A = 0.0;
+    double u1 = atan((1.0 - f) * tan(lat1));
+    double u2 = atan((1.0 - f) * tan(lat2));
+    double cosU1 = cos(u1);
+    double cosU2 = cos(u2);
+    double sinU1 = sin(u1);
+    double sinU2 = sin(u2);
+    double cosU1cosU2 = cosU1 * cosU2;
+    double sinU1sinU2 = sinU1 * sinU2;
+    double sigma = 0.0;
+    double deltaSigma = 0.0;
+    double cosSqAlpha = 0.0;
+    double cos2SM = 0.0;
+    double cosSigma = 0.0;
+    double sinSigma = 0.0;
+    double cosLambda = 0.0;
+    double sinLambda = 0.0;
+    double lambda = L; // initial guess
+    for (int iter = 0; iter < maximeters; iter++) {
+      double lambdaOrig = lambda;
+      cosLambda = cos(lambda);
+      sinLambda = sin(lambda);
+      double t1 = cosU2 * sinLambda;
+      double t2 = cosU1 * sinU2 - sinU1 * cosU2 * cosLambda;
+      double sinSqSigma = t1 * t1 + t2 * t2; // (14)
+      sinSigma = sqrt(sinSqSigma);
+      cosSigma = sinU1sinU2 + cosU1cosU2 * cosLambda; // (15)
+      sigma = atan2(sinSigma, cosSigma); // (16)
+      double sinAlpha =
+          (sinSigma == 0) ? 0.0 : cosU1cosU2 * sinLambda / sinSigma; // (17)
+      cosSqAlpha = 1.0 - sinAlpha * sinAlpha;
+      cos2SM = (cosSqAlpha == 0)
+          ? 0.0
+          : cosSigma - 2.0 * sinU1sinU2 / cosSqAlpha; // (18)
+      double uSquared = cosSqAlpha * aSqMinusBSqOverBSq; // defn
+      A = 1 +
+          (uSquared / 16384.0) * // (3)
+              (4096.0 +
+                  uSquared * (-768 + uSquared * (320.0 - 175.0 * uSquared)));
+      double B = (uSquared / 1024.0) * // (4)
+          (256.0 + uSquared * (-128.0 + uSquared * (74.0 - 47.0 * uSquared)));
+      double C = (f / 16.0) *
+          cosSqAlpha *
+          (4.0 + f * (4.0 - 3.0 * cosSqAlpha)); // (10)
+      double cos2SMSq = cos2SM * cos2SM;
+      deltaSigma = B *
+          sinSigma * // (6)
+          (cos2SM +
+              (B / 4.0) *
+                  (cosSigma * (-1.0 + 2.0 * cos2SMSq) -
+                      (B / 6.0) *
+                          cos2SM *
+                          (-3.0 + 4.0 * sinSigma * sinSigma) *
+                          (-3.0 + 4.0 * cos2SMSq)));
+      lambda = L +
+          (1.0 - C) *
+              f *
+              sinAlpha *
+              (sigma +
+                  C *
+                      sinSigma *
+                      (cos2SM +
+                          C *
+                              cosSigma *
+                              (-1.0 + 2.0 * cos2SM * cos2SM))); // (11)
+      double delta = (lambda - lambdaOrig) / lambda;
+      if (delta.abs() < 1.0e-12) {
+        break;
+      }
+    }
+    double distance = (b * A * (sigma - deltaSigma));
+    return distance;
+  }
+
+  /// Computes whether the given point lies inside the specified polygon.
+  /// The polygon is always considered closed, regardless of whether the last point equals
+  /// the first or not.
+  /// Inside is defined as not containing the South Pole -- the South Pole is always outside.
+  /// The polygon is formed of great circle segments if [geodesic] is true, and of rhumb
+  /// (loxodromic) segments otherwise.
+  ///
+  /// Transcribed to dartlang from PolyUtil.java from android-maps-utils library by Google.
+  /// https://github.com/googlemaps/android-maps-utils
+  static bool containsLocation(
+    double latitude,
+    double longitude,
+    List<LatLng> polygon, {
+    bool geodesic = true,
+  }) {
+    final int size = polygon.length;
+    if (size == 0) {
+      return false;
+    }
+    double lat3 = degToRadian(latitude);
+    double lng3 = degToRadian(longitude);
+    LatLng prev = polygon[size - 1];
+    double lat1 = degToRadian(prev.latitude);
+    double lng1 = degToRadian(prev.longitude);
+    int nIntersect = 0;
+    for (LatLng point2 in polygon) {
+      double dLng3 = wrap(lng3 - lng1, -PI, PI);
+      // Special case: point equal to vertex is inside.
+      if (lat3 == lat1 && dLng3 == 0) {
+        return true;
+      }
+      double lat2 = degToRadian(point2.latitude);
+      double lng2 = degToRadian(point2.longitude);
+      // Offset longitudes by -lng1.
+      if (intersects(lat1, lat2, wrap(lng2 - lng1, -PI, PI), lat3, dLng3,
+          geodesic: geodesic)) {
+        ++nIntersect;
+      }
+      lat1 = lat2;
+      lng1 = lng2;
+    }
+    return (nIntersect & 1) != 0;
+  }
+
+  /// Computes whether the vertical segment (lat3, lng3) to South Pole intersects the segment
+  /// (lat1, lng1) to (lat2, lng2).
+  /// Longitudes are offset by -lng1; the implicit lng1 becomes 0.
+  ///
+  /// Transcribed to dartlang from PolyUtil.java from android-maps-utils library by Google.
+  /// https://github.com/googlemaps/android-maps-utils
+  static bool intersects(
+    double lat1,
+    double lat2,
+    double lng2,
+    double lat3,
+    double lng3, {
+    bool geodesic = true,
+  }) {
+    // Both ends on the same side of lng3.
+    if ((lng3 >= 0 && lng3 >= lng2) || (lng3 < 0 && lng3 < lng2)) {
+      return false;
+    }
+    // Point is South Pole.
+    if (lat3 <= -PI / 2) {
+      return false;
+    }
+    // Any segment end is a pole.
+    if (lat1 <= -PI / 2 ||
+        lat2 <= -PI / 2 ||
+        lat1 >= PI / 2 ||
+        lat2 >= PI / 2) {
+      return false;
+    }
+    if (lng2 <= -PI) {
+      return false;
+    }
+    double linearLat = (lat1 * (lng2 - lng3) + lat2 * lng3) / lng2;
+    // Northern hemisphere and point under lat-lng line.
+    if (lat1 >= 0 && lat2 >= 0 && lat3 < linearLat) {
+      return false;
+    }
+    // Southern hemisphere and point above lat-lng line.
+    if (lat1 <= 0 && lat2 <= 0 && lat3 >= linearLat) {
+      return true;
+    }
+    // North Pole.
+    if (lat3 >= PI / 2) {
+      return true;
+    }
+    // Compare lat3 with latitude on the GC/Rhumb segment corresponding to lng3.
+    // Compare through a strictly-increasing function (tan() or mercator()) as convenient.
+    return geodesic
+        ? tan(lat3) >= tanLatGC(lat1, lat2, lng2, lng3)
+        : mercator(lat3) >= mercatorLatRhumb(lat1, lat2, lng2, lng3);
+  }
+
+  /// Returns the LatLng resulting from moving a distance from an origin
+  /// in the specified heading (expressed in degrees clockwise from north).
+  /// * [from]     The LatLng from which to start.
+  /// * [distance] The distance to travel.
+  /// * [heading]  The heading in degrees clockwise from north.
+  static LatLng computeOffset(LatLng from, double distance, double heading) {
+    distance /= EARTH_RADIUS;
+    heading = degToRadian(heading);
+    // http://williams.best.vwh.net/avform.htm#LL
+    double fromLat = degToRadian(from.latitude);
+    double fromLng = degToRadian(from.longitude);
+    double cosDistance = cos(distance);
+    double sinDistance = sin(distance);
+    double sinFromLat = sin(fromLat);
+    double cosFromLat = cos(fromLat);
+    double sinLat =
+        cosDistance * sinFromLat + sinDistance * cosFromLat * cos(heading);
+    double dLng = atan2(sinDistance * cosFromLat * sin(heading),
+        cosDistance - sinFromLat * sinLat);
+    return LatLng(radianToDeg(asin(sinLat)), radianToDeg(fromLng + dLng));
+  }
+
+  static double computeHeading(LatLng pointA, LatLng pointB) {
+    var y = sin(pointB.longitudeInRad - pointA.longitudeInRad) *
+        cos(pointB.latitudeInRad);
+    var x = cos(pointA.latitudeInRad) * sin(pointB.latitudeInRad) -
+        sin(pointA.latitudeInRad) *
+            cos(pointB.latitudeInRad) *
+            cos(pointB.longitudeInRad - pointA.longitudeInRad);
+    return radianToDeg(atan2(y, x));
+  }
+
+  /// Returns tan(latitude-at-lng3) on the great circle (lat1, lng1) to (lat2, lng2). lng1==0.
+  /// See http://williams.best.vwh.net/avform.htm .
+  ///
+  /// Transcribed to dartlang from PolyUtil.java from android-maps-utils library by Google.
+  /// https://github.com/googlemaps/android-maps-utils
+  static double tanLatGC(double lat1, double lat2, double lng2, double lng3) {
+    return (tan(lat1) * sin(lng2 - lng3) + tan(lat2) * sin(lng3)) / sin(lng2);
+  }
+
+  /// Returns mercator(latitude-at-lng3) on the Rhumb line (lat1, lng1) to (lat2, lng2). lng1==0.
+  ///
+  /// Transcribed to dartlang from PolyUtil.java from android-maps-utils library by Google.
+  /// https://github.com/googlemaps/android-maps-utils
+  static double mercatorLatRhumb(
+      double lat1, double lat2, double lng2, double lng3) {
+    return (mercator(lat1) * (lng2 - lng3) + mercator(lat2) * lng3) / lng2;
+  }
+
+  /// Rotates a point to a determinate amount of degrees clockwise.
+  /// * [center] Observation point to rotate the target from.
+  /// * [pointToRotate] Point that will be rotated.
+  /// * [degrees] Amount of degrees.
+  static LatLng rotateLatLng(
+      LatLng center, LatLng pointToRotate, double degrees) {
+    var xRot = center.longitude +
+        cos(degToRadian(degrees)) *
+            (pointToRotate.longitude - center.longitude) -
+        sin(degToRadian(degrees)) * (pointToRotate.latitude - center.latitude);
+    var yRot = center.latitude +
+        sin(degToRadian(degrees)) *
+            (pointToRotate.longitude - center.longitude) +
+        cos(degToRadian(degrees)) * (pointToRotate.latitude - center.latitude);
+    return LatLng(yRot, xRot);
+  }
+}

--- a/lib/src/core/point.dart
+++ b/lib/src/core/point.dart
@@ -4,45 +4,45 @@ class Point<T extends num> extends math.Point<T> {
   const Point(num x, num y) : super(x, y);
 
   Point<T> operator /(num /*T|int*/ factor) {
-    return new Point<T>(x / factor, y / factor);
+    return Point<T>(x / factor, y / factor);
   }
 
   Point<T> ceil() {
-    return new Point(x.ceil(), y.ceil());
+    return Point(x.ceil(), y.ceil());
   }
 
   Point<T> floor() {
-    return new Point<T>(x.floor(), y.floor());
+    return Point<T>(x.floor(), y.floor());
   }
 
   Point<T> unscaleBy(Point<T> point) {
-    return new Point<T>(x / point.x, y / point.y);
+    return Point<T>(x / point.x, y / point.y);
   }
 
   Point<T> operator +(math.Point<T> other) {
-    return new Point<T>(x + other.x, y + other.y);
+    return Point<T>(x + other.x, y + other.y);
   }
 
   Point<T> operator -(math.Point<T> other) {
-    return new Point<T>(x - other.x, y - other.y);
+    return Point<T>(x - other.x, y - other.y);
   }
 
   Point<T> operator *(num /*T|int*/ factor) {
-    return new Point<T>((x * factor), (y * factor));
+    return Point<T>((x * factor), (y * factor));
   }
 
   Point scaleBy(Point point) {
-    return new Point(this.x * point.x, this.y * point.y);
+    return Point(this.x * point.x, this.y * point.y);
   }
 
   Point round() {
     var x = this.x is double ? this.x.round() : this.x;
     var y = this.y is double ? this.y.round() : this.y;
-    return new Point(x, y);
+    return Point(x, y);
   }
 
   Point multiplyBy(num n) {
-      return new Point(this.x * n, this.y * n);
+      return Point(this.x * n, this.y * n);
   }
 
   String toString() => "Point ($x, $y)";

--- a/lib/src/core/util.dart
+++ b/lib/src/core/util.dart
@@ -1,6 +1,10 @@
+import 'dart:math';
+
 import 'package:tuple/tuple.dart';
 
-var _templateRe = new RegExp(r"\{ *([\w_-]+) *\}");
+const EARTH_CIRCUMFERENCE_METERS = 40075016.686;
+
+var _templateRe = RegExp(r"\{ *([\w_-]+) *\}");
 String template(String str, Map<String, String> data) {
   return str.replaceAllMapped(_templateRe, (Match match) {
     var value = data[match.group(1)];
@@ -17,4 +21,105 @@ double wrapNum(double x, Tuple2<double, double> range, [bool includeMax]) {
   var min = range.item1;
   var d = max - min;
   return x == max && includeMax != null ? x : ((x - min) % d + d) % d + min;
+}
+
+/// Restrict [x] to the range [ [low], [high] ].
+///
+/// Transcribed to dartlang from MathUtil.java from android-maps-utils library by Google. 
+/// https://github.com/googlemaps/android-maps-utils
+double clamp(double x, double low, double high) {
+  return x < low ? low : (x > high ? high : x);
+}
+
+/// Wraps the given value into the inclusive-exclusive interval between min and max.
+/// * [n]   The value to wrap.
+/// * [min] The minimum.
+/// * [max] The maximum.
+///
+/// Transcribed to dartlang from MathUtil.java from android-maps-utils library by Google. 
+/// https://github.com/googlemaps/android-maps-utils
+double wrap(double n, double min, double max) {
+  return (n >= min && n < max) ? n : (mod(n - min, max - min) + min);
+}
+
+/// Returns the non-negative remainder of [x] / [m].
+/// * [x] The operand.
+/// * [m] The modulus.
+///
+/// Transcribed to dartlang from MathUtil.java from android-maps-utils library by Google. 
+/// https://github.com/googlemaps/android-maps-utils
+double mod(double x, double m) {
+  return ((x % m) + m) % m;
+}
+
+/// Returns mercator Y corresponding to latitude.
+/// See http://en.wikipedia.org/wiki/Mercator_projection .
+///
+/// Transcribed to dartlang from MathUtil.java from android-maps-utils library by Google. 
+/// https://github.com/googlemaps/android-maps-utils
+double mercator(double lat) {
+  return log(tan(lat * 0.5 + pi / 4));
+}
+
+/// Returns latitude from mercator Y.
+///
+/// Transcribed to dartlang from MathUtil.java from android-maps-utils library by Google. 
+/// https://github.com/googlemaps/android-maps-utils
+double inverseMercator(double y) {
+  return 2 * atan(exp(y)) - pi / 2;
+}
+
+/// Returns haversine(angle-in-radians).
+/// hav([x]) == (1 - cos([x])) / 2 == sin([x] / 2)^2.
+///
+/// Transcribed to dartlang from MathUtil.java from android-maps-utils library by Google. 
+/// https://github.com/googlemaps/android-maps-utils
+double hav(double x) {
+  double sinHalf = sin(x * 0.5);
+  return sinHalf * sinHalf;
+}
+
+/// Computes inverse haversine. Has good numerical stability around 0.
+/// arcHav([x]) == acos(1 - 2 * [x]) == 2 * asin(sqrt([x])).
+/// The argument must be in [0, 1], and the result is positive.
+///
+/// Transcribed to dartlang from MathUtil.java from android-maps-utils library by Google. 
+/// https://github.com/googlemaps/android-maps-utils
+double arcHav(double x) {
+  return 2 * asin(sqrt(x));
+}
+
+/// Given h==hav(x), returns sin(abs(x)).
+///
+/// Transcribed to dartlang from MathUtil.java from android-maps-utils library by Google. 
+/// https://github.com/googlemaps/android-maps-utils
+double sinFromHav(double h) {
+  return 2 * sqrt(h * (1 - h));
+}
+
+/// Returns hav(asin(x)).
+///
+/// Transcribed to dartlang from MathUtil.java from android-maps-utils library by Google. 
+/// https://github.com/googlemaps/android-maps-utils
+double havFromSin(double x) {
+  double x2 = x * x;
+  return x2 / (1 + sqrt(1 - x2)) * .5;
+}
+
+/// Returns sin(arcHav(x) + arcHav(y)).
+///
+/// Transcribed to dartlang from MathUtil.java from android-maps-utils library by Google. 
+/// https://github.com/googlemaps/android-maps-utils
+double sinSumFromHav(double x, double y) {
+  double a = sqrt(x * (1 - x));
+  double b = sqrt(y * (1 - y));
+  return 2 * (a + b - 2 * (a * y + b * x));
+}
+
+/// Returns hav() of distance from (lat1, lng1) to (lat2, lng2) on the unit sphere.
+///
+/// Transcribed to dartlang from MathUtil.java from android-maps-utils library by Google. 
+/// https://github.com/googlemaps/android-maps-utils
+double havDistance(double lat1, double lat2, double dLng) {
+  return hav(lat1 - lat2) + hav(dLng) * cos(lat1) * cos(lat2);
 }

--- a/lib/src/geo/crs/crs.dart
+++ b/lib/src/geo/crs/crs.dart
@@ -19,7 +19,7 @@ abstract class Crs {
       var scale = this.scale(zoom);
       return transformation.transform(projectedPoint, scale.toDouble());
     } catch (e) {
-      return new Point(0.0, 0.0);
+      return Point(0.0, 0.0);
     }
   }
 
@@ -48,7 +48,7 @@ abstract class Crs {
     var s = this.scale(zoom);
     var min = this.transformation.transform(b.min, s.toDouble());
     var max = this.transformation.transform(b.max, s.toDouble());
-    return new Bounds(min, max);
+    return Bounds(min, max);
   }
 
   bool get infinite;
@@ -87,9 +87,9 @@ class SphericalMercator extends Projection {
   static const int r = 6378137;
   static const double maxLatitude = 85.0511287798;
   static const double _boundsD = r * math.pi;
-  static Bounds<double> _bounds = new Bounds<double>(
-    new Point<double>(-_boundsD, -_boundsD),
-    new Point<double>(_boundsD, _boundsD),
+  static Bounds<double> _bounds = Bounds<double>(
+    Point<double>(-_boundsD, -_boundsD),
+    Point<double>(_boundsD, _boundsD),
   );
 
   const SphericalMercator() : super();
@@ -102,13 +102,13 @@ class SphericalMercator extends Projection {
     var lat = math.max(math.min(max, latlng.latitude), -max);
     var sin = math.sin(lat * d);
 
-    return new Point(
+    return Point(
         r * latlng.longitude * d, r * math.log((1 + sin) / (1 - sin)) / 2);
   }
 
   LatLng unproject(Point point) {
     var d = 180 / math.pi;
-    return new LatLng(
+    return LatLng(
         (2 * math.atan(math.exp(point.y / r)) - (math.pi / 2)) * d,
         point.x * d / r);
   }
@@ -127,7 +127,7 @@ class Transformation {
     }
     var x = scale * (a * point.x + b);
     var y = scale * (c * point.y + d);
-    return new Point(x, y);
+    return Point(x, y);
   }
 
   Point untransform(Point point, double scale) {
@@ -136,6 +136,6 @@ class Transformation {
     }
     var x = (point.x / scale - b) / a;
     var y = (point.y / scale - d) / c;
-    return new Point(x, y);
+    return Point(x, y);
   }
 }

--- a/lib/src/geo/latlng_bounds.dart
+++ b/lib/src/geo/latlng_bounds.dart
@@ -22,8 +22,8 @@ class LatLngBounds {
 
   void _extend(LatLng sw2, LatLng ne2) {
     if (sw == null && ne == null) {
-      sw = new LatLng(sw2.latitude, sw2.longitude);
-      ne = new LatLng(ne2.latitude, ne2.longitude);
+      sw = LatLng(sw2.latitude, sw2.longitude);
+      ne = LatLng(ne2.latitude, ne2.longitude);
     } else {
       sw.latitude = math.min(sw2.latitude, sw.latitude);
       sw.longitude = math.min(sw2.longitude, sw.longitude);
@@ -39,8 +39,8 @@ class LatLngBounds {
 
   LatLng get southWest => sw;
   LatLng get northEast => ne;
-  LatLng get northWest => new LatLng(north, west);
-  LatLng get southEast => new LatLng(south, east);
+  LatLng get northWest => LatLng(north, west);
+  LatLng get southEast => LatLng(south, east);
 
   bool get isValid {
     return sw != null && ne != null;
@@ -49,7 +49,7 @@ class LatLngBounds {
   bool contains(LatLng point) {
     var sw2 = point;
     var ne2 = point;
-    return containsBounds(new LatLngBounds(sw2, ne2));
+    return containsBounds(LatLngBounds(sw2, ne2));
   }
 
   bool containsBounds(LatLngBounds bounds) {

--- a/lib/src/gestures/gestures.dart
+++ b/lib/src/gestures/gestures.dart
@@ -2,6 +2,7 @@ import 'dart:math' as math;
 
 import 'package:flutter/material.dart';
 import 'package:flutter/widgets.dart';
+import 'package:flutter_map/src/core/location_utils.dart';
 import 'package:flutter_map/src/core/point.dart';
 import 'package:flutter_map/src/map/map.dart';
 import 'package:latlong/latlong.dart';
@@ -27,12 +28,14 @@ abstract class MapGestureMixin extends State<FlutterMap>
   MapState get map => mapState;
   MapOptions get options;
 
+  LatLng _latlng;
+
   @override
   void initState() {
     super.initState();
-    _controller = new AnimationController(vsync: this)
+    _controller = AnimationController(vsync: this)
       ..addListener(_handleFlingAnimation);
-    _doubleTapController = new AnimationController(
+    _doubleTapController = AnimationController(
         vsync: this, duration: Duration(milliseconds: 200))
       ..addListener(_handleDoubleTapZoomAnimation);
   }
@@ -87,7 +90,7 @@ abstract class MapGestureMixin extends State<FlutterMap>
     if (magnitude < _kMinFlingVelocity) return;
     final Offset direction = details.velocity.pixelsPerSecond / magnitude;
     final double distance = (Offset.zero & context.size).shortestSide;
-    _flingAnimation = new Tween<Offset>(
+    _flingAnimation = Tween<Offset>(
             begin: _animationOffset,
             end: _animationOffset - direction * distance)
         .animate(_controller);
@@ -97,25 +100,105 @@ abstract class MapGestureMixin extends State<FlutterMap>
   }
 
   void handleTapUp(TapUpDetails details) {
-    if (options.onTap == null) {
-      return;
-    }
     // Get the widget's offset
     var renderObject = context.findRenderObject() as RenderBox;
     var boxOffset = renderObject.localToGlobal(Offset.zero);
     var width = renderObject.size.width;
     var height = renderObject.size.height;
-
     // convert the point to global coordinates
-    var localPoint = _offsetToPoint(details.globalPosition - boxOffset);
-    var localPointCenterDistance =
-        new Point((width / 2) - localPoint.x, (height / 2) - localPoint.y);
-    var mapCenter = map.project(map.center);
-    var point = mapCenter - localPointCenterDistance;
-    var latlng = map.unproject(point);
+    _latlng =
+        map.offsetToLatLng(details.globalPosition, boxOffset, width, height);
+  }
 
-    // emit the event
-    options.onTap(latlng);
+  void handleTap() {
+    if (_latlng == null) {
+      return;
+    }
+    var map = _getElementTouched();
+    if (map != null) {
+      var layer = map.keys.first;
+      if (layer.onTap != null) {
+        layer.onTap(map[layer], _latlng);
+      }
+    } else if (options.onTap != null) options.onTap(_latlng);
+  }
+
+  void handleLongPress() {
+    if (_latlng == null) {
+      return;
+    }
+    var map = _getElementTouched();
+    if (map != null) {
+      var layer = map.keys.first;
+      if (layer.onTap != null) {
+        layer.onLongPress(map[layer], _latlng);
+      }
+    } else if (options.onLongPress != null) options.onLongPress(_latlng);
+  }
+
+  /// Returns a map of the layer and the element toched.
+  Map _getElementTouched() {
+    for (var layer in widget.layers.reversed) {
+      if (layer is PolygonLayerOptions) {
+        var polygon = _getPolygonByLocation(layer);
+        if (polygon != null) return {layer: polygon};
+      } else if (layer is PolylineLayerOptions) {
+        var polyline = _getPolylineByLocation(layer);
+        if (polyline != null) return {layer: polyline};
+      } else if (layer is CircleLayerOptions) {
+        var circle = _getCircleByLocation(layer);
+        if (circle != null) return {layer: circle};
+      }
+    }
+    return null;
+  }
+
+  /// Returns the polygon that contains the [location] and
+  /// is on top of the other polygons.
+  ///
+  /// Returns null if no polygon was touched.
+  Polygon _getPolygonByLocation(PolygonLayerOptions layer) {
+    for (var polygon in layer.polygons.reversed) {
+      if (LocationUtils.containsLocation(
+          _latlng.latitude, _latlng.longitude, polygon.points)) {
+        return polygon;
+      }
+    }
+    return null;
+  }
+
+  /// Returns the polyline that contains the [location] in its path and
+  /// is on top of the other polylines.
+  ///
+  /// Returns null if no polyline was touched.
+  Polyline _getPolylineByLocation(PolylineLayerOptions layer) {
+    for (var polyline in layer.polylines.reversed) {
+      ///Calculates an amount of meters of tolerance for the line
+      ///considering the width. When zoomed out is more dificul to tap on
+      ///the line so this distance helps compensate using the width and
+      ///the meters per pixel for the current zoom level. In conclusion,
+      ///a thicker line will be easier to tap.
+      var meters = map.getMetersPerPixel(_latlng.latitude) *
+          (polyline.strokeWidth * 0.5);
+      if (LocationUtils.isPointInPolyline(_latlng, polyline.points,
+          toleratedDistance: meters)) {
+        return polyline;
+      }
+    }
+    return null;
+  }
+
+  /// Returns the Circle that contains the [location].
+  ///
+  /// Returns null if no Circle was touched.
+  CircleMarker _getCircleByLocation(CircleLayerOptions layer) {
+    for (var circle in layer.circles.reversed) {
+      Circle c = Circle(circle.center, circle.radius);
+      if (c.isPointInside(_latlng)) {
+        return circle;
+      }
+    }
+    return null;
   }
 
   void handleDoubleTap() {
@@ -132,11 +215,11 @@ abstract class MapGestureMixin extends State<FlutterMap>
 
     double newZoom = _mapZoomStart * dScale;
 
-    _doubleTapAnimation = new Tween<double>(
+    _doubleTapAnimation = Tween<double>(
       begin: _mapZoomStart,
       end: newZoom,
     )
-        .chain(new CurveTween(curve: Curves.fastOutSlowIn))
+        .chain(CurveTween(curve: Curves.fastOutSlowIn))
         .animate(_doubleTapController);
     _doubleTapController
       ..value = 0.0
@@ -154,18 +237,18 @@ abstract class MapGestureMixin extends State<FlutterMap>
     setState(() {
       _animationOffset = _flingAnimation.value;
       var newCenterPoint = map.project(_mapCenterStart) +
-          new Point(_animationOffset.dx, _animationOffset.dy);
+          Point(_animationOffset.dx, _animationOffset.dy);
       var newCenter = map.unproject(newCenterPoint);
       map.move(newCenter, map.zoom);
     });
   }
 
   Point _offsetToPoint(Offset offset) {
-    return new Point(offset.dx, offset.dy);
+    return Point(offset.dx, offset.dy);
   }
 
   Offset _pointToOffset(Point point) {
-    return new Offset(point.x.toDouble(), point.y.toDouble());
+    return Offset(point.x.toDouble(), point.y.toDouble());
   }
 
   @override

--- a/lib/src/layer/circle_layer.dart
+++ b/lib/src/layer/circle_layer.dart
@@ -2,23 +2,46 @@ import 'dart:ui';
 
 import 'package:flutter/widgets.dart';
 import 'package:flutter_map/flutter_map.dart';
+import 'package:flutter_map/src/core/location_utils.dart';
 import 'package:flutter_map/src/map/map.dart';
 import 'package:latlong/latlong.dart' hide Path; // conflict with Path from UI
 
+typedef CircleCallback(CircleMarker circle, LatLng location);
+
 class CircleLayerOptions extends LayerOptions {
   final List<CircleMarker> circles;
-  CircleLayerOptions({this.circles = const []});
+  final CircleCallback onTap;
+  final CircleCallback onLongPress;
+
+  CircleLayerOptions({
+    this.circles = const [],
+    this.onTap,
+    this.onLongPress,
+  });
 }
 
 class CircleMarker {
-  final LatLng point;
+  /// A [Key] to identify the [Circle]
+  final Key key;
+
+  /// The center of the Circle is specified as a [LatLng].
+  final LatLng center;
+
+  /// The radius of the circle, specified in meters. It should be zero or greater.
   final double radius;
+
+  /// The color of the circle.
   final Color color;
+
+  /// The width of the circle's outline.
   final double borderStrokeWidth;
+
+  /// The color of the circle's outline.
   final Color borderColor;
-  Offset offset = Offset.zero;
+  List<Offset> offsets = [];
   CircleMarker({
-    this.point,
+    this.key,
+    this.center,
     this.radius,
     this.color = const Color(0xFF00FF00),
     this.borderStrokeWidth = 0.0,
@@ -31,35 +54,44 @@ class CircleLayer extends StatelessWidget {
   final MapState map;
   CircleLayer(this.circleOpts, this.map);
 
+  @override
   Widget build(BuildContext context) {
-    return new LayoutBuilder(
+    return LayoutBuilder(
       builder: (BuildContext context, BoxConstraints bc) {
-        final size = new Size(bc.maxWidth, bc.maxHeight);
+        final size = Size(bc.maxWidth, bc.maxHeight);
         return _build(context, size);
       },
     );
   }
 
   Widget _build(BuildContext context, Size size) {
-    return new StreamBuilder<int>(
+    return StreamBuilder<int>(
       stream: map.onMoved, // a Stream<int> or null
       builder: (BuildContext context, _) {
         var circleWidgets = <Widget>[];
         for (var circle in circleOpts.circles) {
-          var pos = map.project(circle.point);
-          pos = pos.multiplyBy(map.getZoomScale(map.zoom, map.zoom)) -
-              map.getPixelOrigin();
-          circle.offset = new Offset(pos.x.toDouble(), pos.y.toDouble());
+          circle.offsets.clear();
+          var idx = 0;
+          for (int i = 0; i <= 360; i++) {
+            LatLng point = LocationUtils.computeOffset(
+                circle.center, circle.radius, i.toDouble());
+            var offset = map.latlngToOffset(point);
+            circle.offsets.add(offset);
+            if (idx > 0 && idx < 360) {
+              circle.offsets.add(offset);
+            }
+            idx++;
+          }
           circleWidgets.add(
-            new CustomPaint(
-              painter: new CirclePainter(circle),
+            CustomPaint(
+              key: circle.key,
               size: size,
+              painter: CirclePainter(circle),
             ),
           );
         }
-
-        return new Container(
-          child: new Stack(
+        return Container(
+          child: Stack(
             children: circleWidgets,
           ),
         );
@@ -74,23 +106,34 @@ class CirclePainter extends CustomPainter {
 
   @override
   void paint(Canvas canvas, Size size) {
+    if (circle.offsets.isEmpty) {
+      return;
+    }
     final rect = Offset.zero & size;
     canvas.clipRect(rect);
-    final paint = new Paint()
+    final paint = Paint()
       ..style = PaintingStyle.fill
       ..color = circle.color;
-
     final borderPaint = circle.borderStrokeWidth > 0.0
-        ? (new Paint()
+        ? (Paint()
+          ..style = PaintingStyle.stroke
           ..color = circle.borderColor
           ..strokeWidth = circle.borderStrokeWidth)
         : null;
-
-    _paintCircle(canvas, circle.offset, circle.radius, paint);
+    _paintCircle(canvas, paint);
+    if (circle.borderStrokeWidth > 0.0) {
+      _paintLine(canvas, borderPaint);
+    }
   }
 
-  void _paintCircle(Canvas canvas, Offset offset, double radius, Paint paint) {
-    canvas.drawCircle(offset, radius, paint);
+  void _paintLine(Canvas canvas, Paint paint) {
+    canvas.drawPoints(PointMode.lines, circle.offsets, paint);
+  }
+
+  void _paintCircle(Canvas canvas, Paint paint) {
+    Path path = Path();
+    path.addPolygon(circle.offsets, true);
+    canvas.drawPath(path, paint);
   }
 
   @override

--- a/lib/src/layer/marker_layer.dart
+++ b/lib/src/layer/marker_layer.dart
@@ -70,7 +70,7 @@ class Marker {
     this.height = 30.0,
     AnchorPos anchor,
     Anchor anchorOverride,
-  }) : this._anchor = anchorOverride ?? new Anchor._(width, height, anchor);
+  }) : this._anchor = anchorOverride ?? Anchor._(width, height, anchor);
 }
 
 class MarkerLayer extends StatelessWidget {
@@ -81,7 +81,7 @@ class MarkerLayer extends StatelessWidget {
   MarkerLayer(this.markerOpts, this.map, this.stream);
 
   Widget build(BuildContext context) {
-    return new StreamBuilder<int>(
+    return StreamBuilder<int>(
       stream: stream, // a Stream<int> or null
       builder: (BuildContext context, AsyncSnapshot<int> snapshot) {
         var markers = <Widget>[];
@@ -100,7 +100,7 @@ class MarkerLayer extends StatelessWidget {
           }
 
           markers.add(
-            new Positioned(
+            Positioned(
               width: markerOpt.width,
               height: markerOpt.height,
               left: pixelPosX,
@@ -109,8 +109,8 @@ class MarkerLayer extends StatelessWidget {
             ),
           );
         }
-        return new Container(
-          child: new Stack(
+        return Container(
+          child: Stack(
             children: markers,
           ),
         );

--- a/lib/src/layer/polygon_layer.dart
+++ b/lib/src/layer/polygon_layer.dart
@@ -4,25 +4,46 @@ import 'dart:ui';
 import 'package:flutter/widgets.dart';
 import 'package:flutter_map/flutter_map.dart';
 import 'package:flutter_map/src/map/map.dart';
-import 'package:latlong/latlong.dart' hide Path;  // conflict with Path from UI
+import 'package:latlong/latlong.dart' hide Path; // conflict with Path from UI
+
+typedef PolygonCallback(Polygon polygon, LatLng location);
 
 class PolygonLayerOptions extends LayerOptions {
   final List<Polygon> polygons;
-  PolygonLayerOptions({this.polygons = const [], rebuild})
-      : super(rebuild: rebuild);
+  final PolygonCallback onTap;
+  final PolygonCallback onLongPress;
+
+  PolygonLayerOptions({
+    this.polygons = const [],
+    this.onTap,
+    this.onLongPress,
+  });
 }
 
 class Polygon {
+  final Key key;
   final List<LatLng> points;
   final List<Offset> offsets = [];
   final Color color;
   final double borderStrokeWidth;
   final Color borderColor;
+  final bool closeFigure;
+  final bool displayPoints;
+  final double pointsWidth;
+
+  bool get isEmpty => this.points == null || this.points.isEmpty;
+
+  bool get isNotEmpty => this.points != null && this.points.isNotEmpty;
+
   Polygon({
+    this.key,
     this.points,
     this.color = const Color(0xFF00FF00),
     this.borderStrokeWidth = 0.0,
     this.borderColor = const Color(0xFFFFFF00),
+    this.closeFigure = false,
+    this.displayPoints = false,
+    this.pointsWidth = 0.0,
   });
 }
 
@@ -34,105 +55,97 @@ class PolygonLayer extends StatelessWidget {
   PolygonLayer(this.polygonOpts, this.map, this.stream);
 
   Widget build(BuildContext context) {
-    return new LayoutBuilder(
+    return LayoutBuilder(
       builder: (BuildContext context, BoxConstraints bc) {
-        final size = new Size(bc.maxWidth, bc.maxHeight);
+        final size = Size(bc.maxWidth, bc.maxHeight);
         return _build(context, size);
       },
     );
   }
 
   Widget _build(BuildContext context, Size size) {
-    return new StreamBuilder<int>(
-      stream: stream, // a Stream<int> or null
-      builder: (BuildContext context, _) {
-        for (var polygonOpt in polygonOpts.polygons) {
-          polygonOpt.offsets.clear();
-          var i = 0;
-          for (var point in polygonOpt.points) {
-            var pos = map.project(point);
-            pos = pos.multiplyBy(map.getZoomScale(map.zoom, map.zoom)) - map.getPixelOrigin();
-            polygonOpt.offsets.add(new Offset(pos.x.toDouble(), pos.y.toDouble()));
-            if (i > 0 && i < polygonOpt.points.length) {
-              polygonOpt.offsets.add(new Offset(pos.x.toDouble(), pos.y.toDouble()));
-            }
-            i++;
-          }
-        }
-
-        var polygons = <Widget>[];
-        for (var polygonOpt in this.polygonOpts.polygons) {
-          polygons.add(
-            new CustomPaint(
-              painter: new PolygonPainter(polygonOpt),
-              size: size,
-            ),
-          );
-        }
-
-        return new Container(
-          child: new Stack(
-            children: polygons,
+    return StreamBuilder<int>(
+      stream: map.onMoved, // a Stream<int> or null
+      builder: (BuildContext context, AsyncSnapshot<int> snapshot) {
+        return Container(
+          child: Stack(
+            children: _buildPolygons(size),
           ),
         );
       },
     );
   }
+
+  List<Widget> _buildPolygons(Size size) {
+    var list = polygonOpts.polygons
+        .where((polygon) => polygon.isNotEmpty)
+        .map((polygon) => _buildPolygonWidget(polygon, size))
+        .toList();
+    return list;
+  }
+
+  Widget _buildPolygonWidget(Polygon polygon, Size size) {
+    polygon.offsets.clear();
+    if (polygon.closeFigure && polygon.points.length > 2)
+      polygon.points.add(polygon.points.first);
+    var i = 0;
+    for (var point in polygon.points) {
+      var offset = map.latlngToOffset(point);
+      polygon.offsets.add(offset);
+      if (i > 0 && i < polygon.points.length) {
+        polygon.offsets.add(offset);
+      }
+      i++;
+    }
+    return CustomPaint(
+      key: polygon.key,
+      painter: PolygonPainter(polygon),
+      size: size,
+    );
+  }
 }
 
 class PolygonPainter extends CustomPainter {
-  final Polygon polygonOpt;
-  PolygonPainter(this.polygonOpt);
+  final Polygon polygon;
+  PolygonPainter(this.polygon);
 
   @override
   void paint(Canvas canvas, Size size) {
-    if (polygonOpt.offsets.isEmpty) {
+    if (polygon.offsets.isEmpty) {
       return;
     }
     final rect = Offset.zero & size;
     canvas.clipRect(rect);
-    final paint = new Paint()
+    final paint = Paint()
       ..style = PaintingStyle.fill
-      ..color = polygonOpt.color;
-    final borderPaint = polygonOpt.borderStrokeWidth > 0.0
-        ? (new Paint()
-      ..color = polygonOpt.borderColor
-      ..strokeWidth = polygonOpt.borderStrokeWidth)
+      ..color = polygon.color;
+    final borderPaint = polygon.borderStrokeWidth > 0.0
+        ? (Paint()
+          ..style = PaintingStyle.stroke
+          ..color = polygon.borderColor
+          ..strokeWidth = polygon.borderStrokeWidth)
         : null;
-
-    _paintPolygon(canvas, polygonOpt.offsets, paint);
-
-    double borderRadius = (polygonOpt.borderStrokeWidth / 2);
-    if (polygonOpt.borderStrokeWidth > 0.0) {
-        _paintLine(canvas, polygonOpt.offsets, borderRadius, borderPaint);
+    _paintPolygon(canvas, paint);
+    if (polygon.borderStrokeWidth > 0.0) {
+      _paintLine(canvas, borderPaint);
     }
   }
 
-  void _paintLine(Canvas canvas, List<Offset> offsets, double radius, Paint paint) {
-    canvas.drawPoints(PointMode.lines, offsets, paint);
-    for (var offset in offsets) {
-      canvas.drawCircle(offset, radius, paint);
+  void _paintLine(Canvas canvas, Paint paint) {
+    canvas.drawPoints(PointMode.lines, polygon.offsets, paint);
+    if (polygon.displayPoints && polygon.pointsWidth > 0.0) {
+      for (var offset in polygon.offsets) {
+        canvas.drawCircle(offset, polygon.pointsWidth, paint);
+      }
     }
   }
 
-  void _paintPolygon(Canvas canvas, List<Offset> offsets, Paint paint) {
-    Path path = new Path();
-    path.addPolygon(offsets, true);
+  void _paintPolygon(Canvas canvas, Paint paint) {
+    Path path = Path();
+    path.addPolygon(polygon.offsets, true);
     canvas.drawPath(path, paint);
   }
 
   @override
   bool shouldRepaint(PolygonPainter other) => false;
-}
-
-double _dist(Offset v, Offset w) {
-  return sqrt(_dist2(v, w));
-}
-
-double _dist2(Offset v, Offset w) {
-  return _sqr(v.dx - w.dx) + _sqr(v.dy - w.dy);
-}
-
-double _sqr(double x) {
-  return x * x;
 }

--- a/lib/src/layer/tile_layer.dart
+++ b/lib/src/layer/tile_layer.dart
@@ -110,7 +110,7 @@ class TileLayer extends StatefulWidget {
   });
 
   State<StatefulWidget> createState() {
-    return new _TileLayerState();
+    return _TileLayerState();
   }
 }
 
@@ -153,7 +153,7 @@ class _TileLayerState extends State<TileLayer> {
       'z': coords.z.round().toString(),
       's': _getSubdomain(coords)
     };
-    Map<String, String> allOpts = new Map.from(data)
+    Map<String, String> allOpts = Map.from(data)
       ..addAll(this.options.additionalOptions);
     return util.template(this.options.urlTemplate, allOpts);
   }
@@ -195,13 +195,13 @@ class _TileLayerState extends State<TileLayer> {
     var map = this.map;
 
     if (level == null) {
-      level = _levels[zoom] = new Level();
+      level = _levels[zoom] = Level();
       level.zIndex = maxZoom;
       var newOrigin = map.project(map.unproject(map.getPixelOrigin()), zoom);
       if (newOrigin != null) {
         level.origin = newOrigin;
       } else {
-        level.origin = new Point(0.0, 0.0);
+        level.origin = Point(0.0, 0.0);
       }
       level.zoom = zoom;
 
@@ -216,13 +216,13 @@ class _TileLayerState extends State<TileLayer> {
     var pixelBounds = this._getTiledPixelBounds(center);
     var tileRange = _pxBoundsToTileRange(pixelBounds);
     var margin = this.options.keepBuffer ?? 2;
-    var noPruneRange = new Bounds(
-        tileRange.bottomLeft - new Point(margin, -margin),
-        tileRange.topRight + new Point(margin, -margin));
+    var noPruneRange = Bounds(
+        tileRange.bottomLeft - Point(margin, -margin),
+        tileRange.topRight + Point(margin, -margin));
     for (var tileKey in _tiles.keys) {
       var tile = _tiles[tileKey];
       var c = tile.coords;
-      if (c.z != _tileZoom || !noPruneRange.contains(new Point(c.x, c.y))) {
+      if (c.z != _tileZoom || !noPruneRange.contains(Point(c.x, c.y))) {
         tile.current = false;
       }
     }
@@ -281,30 +281,30 @@ class _TileLayerState extends State<TileLayer> {
     // wrapping
     this._wrapX = crs.wrapLng;
     if (_wrapX != null) {
-      var first = (map.project(new LatLng(0.0, crs.wrapLng.item1), tileZoom).x /
+      var first = (map.project(LatLng(0.0, crs.wrapLng.item1), tileZoom).x /
               tileSize.x)
           .floor()
           .toDouble();
       var second =
-          (map.project(new LatLng(0.0, crs.wrapLng.item2), tileZoom).x /
+          (map.project(LatLng(0.0, crs.wrapLng.item2), tileZoom).x /
                   tileSize.y)
               .ceil()
               .toDouble();
-      _wrapX = new Tuple2(first, second);
+      _wrapX = Tuple2(first, second);
     }
 
     this._wrapY = crs.wrapLat;
     if (_wrapY != null) {
-      var first = (map.project(new LatLng(crs.wrapLat.item1, 0.0), tileZoom).y /
+      var first = (map.project(LatLng(crs.wrapLat.item1, 0.0), tileZoom).y /
               tileSize.x)
           .floor()
           .toDouble();
       var second =
-          (map.project(new LatLng(crs.wrapLat.item2, 0.0), tileZoom).y /
+          (map.project(LatLng(crs.wrapLat.item2, 0.0), tileZoom).y /
                   tileSize.y)
               .ceil()
               .toDouble();
-      _wrapY = new Tuple2(first, second);
+      _wrapY = Tuple2(first, second);
     }
   }
 
@@ -314,7 +314,7 @@ class _TileLayerState extends State<TileLayer> {
   }
 
   Point getTileSize() {
-    return new Point(options.tileSize, options.tileSize);
+    return Point(options.tileSize, options.tileSize);
   }
 
   Widget build(BuildContext context) {
@@ -335,7 +335,7 @@ class _TileLayerState extends State<TileLayer> {
 
     for (var j = tileRange.min.y; j <= tileRange.max.y; j++) {
       for (var i = tileRange.min.x; i <= tileRange.max.x; i++) {
-        var coords = new Coords(i.toDouble(), j.toDouble());
+        var coords = Coords(i.toDouble(), j.toDouble());
         coords.z = this._tileZoom;
 
         if (!this._isValidTile(coords)) {
@@ -350,7 +350,7 @@ class _TileLayerState extends State<TileLayer> {
     if (queue.length > 0) {
       for (var i = 0; i < queue.length; i++) {
         _tiles[_tileCoordsToKey(queue[i])] =
-            new Tile(_wrapCoords(queue[i]), true);
+            Tile(_wrapCoords(queue[i]), true);
       }
     }
 
@@ -376,8 +376,8 @@ class _TileLayerState extends State<TileLayer> {
       tileWidgets.add(_createTileWidget(tile.coords));
     }
 
-    return new Container(
-      child: new Stack(
+    return Container(
+      child: Stack(
         children: tileWidgets,
       ),
       color: this.options.backgroundColor,
@@ -390,9 +390,9 @@ class _TileLayerState extends State<TileLayer> {
 
   Bounds _pxBoundsToTileRange(Bounds bounds) {
     var tileSize = this.getTileSize();
-    return new Bounds(
+    return Bounds(
       bounds.min.unscaleBy(tileSize).floor(),
-      bounds.max.unscaleBy(tileSize).ceil() - new Point(1, 1),
+      bounds.max.unscaleBy(tileSize).ceil() - Point(1, 1),
     );
   }
 
@@ -422,18 +422,18 @@ class _TileLayerState extends State<TileLayer> {
     var width = tileSize.x * level.scale;
     var height = tileSize.y * level.scale;
 
-    return new Positioned(
+    return Positioned(
       left: pos.x.toDouble(),
       top: pos.y.toDouble(),
       width: width.toDouble(),
       height: height.toDouble(),
-      child: new Container(
-        child: new FadeInImage(
+      child: Container(
+        child: FadeInImage(
           fadeInDuration: const Duration(milliseconds: 100),
-          key: new Key(_tileCoordsToKey(coords)),
+          key: Key(_tileCoordsToKey(coords)),
           placeholder: options.placeholderImage != null
               ? options.placeholderImage
-              : new MemoryImage(kTransparentImage),
+              : MemoryImage(kTransparentImage),
           image: _getImageProvider(getTileUrl(coords)),
           fit: BoxFit.fill,
         ),
@@ -444,17 +444,17 @@ class _TileLayerState extends State<TileLayer> {
   ImageProvider _getImageProvider(String url) {
     if (options.offlineMode) {
       if (options.fromAssets) {
-        return new AssetImage(url);
+        return AssetImage(url);
       } else {
-        return new FileImage(new File(url));
+        return FileImage(File(url));
       }
     } else {
-      return new NetworkImageWithRetry(url);
+      return NetworkImageWithRetry(url);
     }
   }
 
   Coords _wrapCoords(Coords coords) {
-    var newCoords = new Coords(
+    var newCoords = Coords(
       _wrapX != null
           ? util.wrapNum(coords.x.toDouble(), _wrapX)
           : coords.x.toDouble(),

--- a/lib/src/map/flutter_map_state.dart
+++ b/lib/src/map/flutter_map_state.dart
@@ -8,14 +8,14 @@ import 'package:async/async.dart';
 class FlutterMapState extends MapGestureMixin {
   final MapControllerImpl mapController;
   final List<StreamGroup<Null>> groups = <StreamGroup<Null>>[];
-  MapOptions get options => widget.options ?? new MapOptions();
+  MapOptions get options => widget.options ?? MapOptions();
   MapState mapState;
 
   FlutterMapState(this.mapController);
 
   initState() {
     super.initState();
-    mapState = new MapState(options);
+    mapState = MapState(options);
     mapController.state = mapState;
   }
 
@@ -34,8 +34,7 @@ class FlutterMapState extends MapGestureMixin {
   Stream<Null> _merge(LayerOptions options) {
     if(options?.rebuild == null)
       return mapState.onMoved;
-
-    StreamGroup<Null> group = new StreamGroup<Null>();
+    StreamGroup<Null> group = StreamGroup<Null>();
     group.add(mapState.onMoved);
     group.add(options.rebuild);
     groups.add(group);
@@ -44,23 +43,25 @@ class FlutterMapState extends MapGestureMixin {
 
   Widget build(BuildContext context) {
     _dispose();
-    return new LayoutBuilder(
+    return LayoutBuilder(
         builder: (BuildContext context, BoxConstraints constraints) {
       mapState.size =
-          new Point<double>(constraints.maxWidth, constraints.maxHeight);
+          Point<double>(constraints.maxWidth, constraints.maxHeight);
       var layerWidgets = widget.layers
           .map((layer) => _createLayer(layer, widget.options.plugins))
           .toList();
-      return new GestureDetector(
+      return GestureDetector(
         onScaleStart: handleScaleStart,
         onScaleUpdate: handleScaleUpdate,
         onScaleEnd: handleScaleEnd,
         onTapUp: handleTapUp,
         onDoubleTap: handleDoubleTap,
-        child: new Container(
+        onTap: handleTap,
+        onLongPress: handleLongPress,
+        child: Container(
           width: constraints.maxWidth,
           height: constraints.maxHeight,
-          child: new Stack(
+          child: Stack(
             children: layerWidgets,
           ),
         ),
@@ -70,19 +71,19 @@ class FlutterMapState extends MapGestureMixin {
 
   Widget _createLayer(LayerOptions options, List<MapPlugin> plugins) {
     if (options is TileLayerOptions) {
-      return new TileLayer(options: options, mapState: mapState, stream: _merge(options));
+      return TileLayer(options: options, mapState: mapState, stream: _merge(options));
     }
     if (options is MarkerLayerOptions) {
-      return new MarkerLayer(options, mapState, _merge(options));
+      return MarkerLayer(options, mapState, _merge(options));
     }
     if (options is PolylineLayerOptions) {
-      return new PolylineLayer(options, mapState, _merge(options));
+      return PolylineLayer(options, mapState, _merge(options));
     }
     if (options is PolygonLayerOptions) {
-      return new PolygonLayer(options, mapState, _merge(options));
+      return PolygonLayer(options, mapState, _merge(options));
     }
     if (options is CircleLayerOptions) {
-      return new CircleLayer(options, mapState);
+      return CircleLayer(options, mapState);
     }
     for (var plugin in plugins) {
       if (plugin.supportsLayer(options)) {


### PR DESCRIPTION
* Added polygon, polyline & circle callback support for onTap & onLongPress events. **
* Removed "new" for instance creation in the project (the code looks better without them, they are optional anyway)
* Updated Gradle plugin and build.tools to 28.0.3 in the example project.
* Added pages in the example project for polygon & circles. (I used them to test the callback)

** Added multiple functions for this matter and part of them are Dart implementation of functions from android-maps-utils (https://github.com/googlemaps/android-maps-utils) in github, this functions are originally written in Java. The functions transcribed have a legend in the documentation of each functions. I don't know if this is a problem (license related, android-maps-utils have an Apache-2.0 license) but i hope not.